### PR TITLE
Introduce the LEASE mechanism.

### DIFF
--- a/src/main/java/io/reactivesocket/FairLeaseGovernor.java
+++ b/src/main/java/io/reactivesocket/FairLeaseGovernor.java
@@ -1,0 +1,70 @@
+package io.reactivesocket;
+
+import io.reactivesocket.internal.Responder;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Distribute evenly a static number of tickets to all connected clients.
+ */
+public class FairLeaseGovernor implements LeaseGovernor {
+    private static ScheduledExecutorService EXECUTOR = Executors.newScheduledThreadPool(1);
+
+    private final int tickets;
+    private final long period;
+    private final TimeUnit unit;
+    private final Set<Responder> responders;
+    private ScheduledFuture<?> runningTask;
+
+    private synchronized void distribute(long ttlMs) {
+        if (!responders.isEmpty()) {
+            int budget = tickets / responders.size();
+
+            // it would be more fair to randomized the distribution of extra
+            int extra = tickets - budget * responders.size();
+            for (Responder responder : responders) {
+                int n = budget;
+                if (extra > 0) {
+                    n += 1;
+                    extra -= 1;
+                }
+                responder.sendLease(ttlMs, n);
+            }
+        }
+    }
+
+    public FairLeaseGovernor(int tickets, long period, TimeUnit unit) {
+        this.tickets = tickets;
+        this.period = period;
+        this.unit = unit;
+        responders = new HashSet<>();
+    }
+
+    @Override
+    public synchronized void register(Responder responder) {
+        responders.add(responder);
+        if (runningTask == null) {
+            final long ttl = TimeUnit.NANOSECONDS.convert(period, unit);
+            runningTask = EXECUTOR.scheduleAtFixedRate(() -> distribute(ttl), 0, period, unit);
+        }
+    }
+
+    @Override
+    public synchronized void unregister(Responder responder) {
+        responders.remove(responder);
+        if (responders.isEmpty() && runningTask != null) {
+            runningTask.cancel(true);
+            runningTask = null;
+        }
+    }
+
+    @Override
+    public void notify(Responder responder, Frame requestFrame) {
+
+    }
+}

--- a/src/main/java/io/reactivesocket/LeaseGovernor.java
+++ b/src/main/java/io/reactivesocket/LeaseGovernor.java
@@ -1,0 +1,12 @@
+package io.reactivesocket;
+
+import io.reactivesocket.internal.Responder;
+
+public interface LeaseGovernor {
+    public static final LeaseGovernor NULL_LEASE_GOVERNOR = new NullLeaseGovernor();
+    public static final LeaseGovernor UNLIMITED_LEASE_GOVERNOR = new UnlimitedLeaseGovernor();
+
+    void register(Responder responder);
+    void unregister(Responder responder);
+    void notify(Responder responder, Frame requestFrame);
+}

--- a/src/main/java/io/reactivesocket/NullLeaseGovernor.java
+++ b/src/main/java/io/reactivesocket/NullLeaseGovernor.java
@@ -1,0 +1,14 @@
+package io.reactivesocket;
+
+import io.reactivesocket.internal.Responder;
+
+public class NullLeaseGovernor implements LeaseGovernor {
+    @Override
+    public void register(Responder responder) {}
+
+    @Override
+    public void unregister(Responder responder) {}
+
+    @Override
+    public void notify(Responder responder, Frame requestFrame) {}
+}

--- a/src/main/java/io/reactivesocket/UnlimitedLeaseGovernor.java
+++ b/src/main/java/io/reactivesocket/UnlimitedLeaseGovernor.java
@@ -1,0 +1,16 @@
+package io.reactivesocket;
+
+import io.reactivesocket.internal.Responder;
+
+public class UnlimitedLeaseGovernor implements LeaseGovernor {
+    @Override
+    public void register(Responder responder) {
+        responder.sendLease(Long.MAX_VALUE, Long.MAX_VALUE);
+    }
+
+    @Override
+    public void unregister(Responder responder) {}
+
+    @Override
+    public void notify(Responder responder, Frame requestFrame) {}
+}

--- a/src/test/java/io/reactivesocket/RequesterResponderInteractionTest.java
+++ b/src/test/java/io/reactivesocket/RequesterResponderInteractionTest.java
@@ -15,6 +15,7 @@
  */
 package io.reactivesocket;
 
+import static io.reactivesocket.LeaseGovernor.NULL_LEASE_GOVERNOR;
 import static org.junit.Assert.assertEquals;
 import static rx.Observable.empty;
 import static rx.Observable.error;
@@ -123,7 +124,7 @@ public class RequesterResponderInteractionTest
                 {
                     return toPublisher(error(new Exception("Not Found!")));
                 }
-            }), err -> err.printStackTrace());
+            }), NULL_LEASE_GOVERNOR, err -> err.printStackTrace());
 
         requester = Requester.createClientRequester(clientConnection, ConnectionSetupPayload.create("UTF-8", "UTF-8"), err -> err.printStackTrace());
     }

--- a/src/test/java/io/reactivesocket/TestConnection.java
+++ b/src/test/java/io/reactivesocket/TestConnection.java
@@ -49,7 +49,8 @@ public class TestConnection implements DuplexConnection {
 
 	public void connectToServerConnection(TestConnection serverConnection) {
 		serverConnection.writes.forEach(n -> System.out.println("SERVER ==> Writes from server->client: " + n));
-		serverConnection.toInput.forEach(n -> System.out.println("SERVER <== Input from client->server: " + n));
+		serverConnection.toInput.forEach(n ->
+			System.out.println("SERVER <== Input from client->server: " + n));
 		writes.forEach(n -> System.out.println("CLIENT ==> Writes from client->server: " + n));
 		toInput.forEach(n -> System.out.println("CLIENT <== Input from server->client: " + n));
 

--- a/src/test/java/io/reactivesocket/internal/ResponderTest.java
+++ b/src/test/java/io/reactivesocket/internal/ResponderTest.java
@@ -17,15 +17,11 @@ package io.reactivesocket.internal;
 
 import static io.reactivesocket.TestUtil.*;
 
+import io.reactivesocket.*;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 
-import io.reactivesocket.Frame;
-import io.reactivesocket.FrameType;
-import io.reactivesocket.Payload;
-import io.reactivesocket.RequestHandler;
-import io.reactivesocket.TestConnection;
-import io.reactivesocket.internal.Responder;
+import static io.reactivesocket.LeaseGovernor.NULL_LEASE_GOVERNOR;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
@@ -55,7 +51,7 @@ public class ResponderTest
     	TestConnection conn = establishConnection();
         Responder.create(conn, setup -> RequestHandler.create(
             request -> toPublisher(just(utf8EncodedPayload(byteToString(request.getData()) + " world", null))),
-            null, null, null), ERROR_HANDLER);
+            null, null, null), NULL_LEASE_GOVERNOR, ERROR_HANDLER);
 
         
         ReplaySubject<Frame> cachedResponses = captureResponses(conn);
@@ -79,7 +75,7 @@ public class ResponderTest
     	TestConnection conn = establishConnection();
         Responder.create(conn, setup -> RequestHandler.create(
             request -> toPublisher(Observable.<Payload>error(new Exception("Request Not Found"))),
-            null, null, null), ERROR_HANDLER);
+            null, null, null), NULL_LEASE_GOVERNOR, ERROR_HANDLER);
 
         Observable<Frame> cachedResponses = captureResponses(conn);
         sendSetupFrame(conn);
@@ -104,7 +100,7 @@ public class ResponderTest
         TestConnection conn = establishConnection();
         Responder.create(conn, setup -> RequestHandler.create(
             request -> toPublisher(delayed),
-            null, null, null), ERROR_HANDLER);
+            null, null, null), NULL_LEASE_GOVERNOR, ERROR_HANDLER);
 
         ReplaySubject<Frame> cachedResponses = captureResponses(conn);
         sendSetupFrame(conn);
@@ -125,7 +121,7 @@ public class ResponderTest
         Responder.create(conn, setup -> RequestHandler.create(
             null,
             request -> toPublisher(range(Integer.parseInt(byteToString(request.getData())), 10).map(i -> utf8EncodedPayload(i + "!", null))),
-            null, null), ERROR_HANDLER);
+            null, null), NULL_LEASE_GOVERNOR, ERROR_HANDLER);
 
         ReplaySubject<Frame> cachedResponses = captureResponses(conn);
         sendSetupFrame(conn);
@@ -158,7 +154,7 @@ public class ResponderTest
             request -> toPublisher(range(Integer.parseInt(byteToString(request.getData())), 3)
                 .map(i -> utf8EncodedPayload(i + "!", null))
                 .concatWith(error(new Exception("Error Occurred!")))),
-            null, null), ERROR_HANDLER);
+            null, null), NULL_LEASE_GOVERNOR, ERROR_HANDLER);
 
         ReplaySubject<Frame> cachedResponses = captureResponses(conn);
         sendSetupFrame(conn);
@@ -190,7 +186,7 @@ public class ResponderTest
         Responder.create(conn, setup -> RequestHandler.create(
             null,
             request -> toPublisher(interval(1000, TimeUnit.MILLISECONDS, ts).map(i -> utf8EncodedPayload(i + "!", null))),
-            null, null), ERROR_HANDLER);
+            null, null), NULL_LEASE_GOVERNOR, ERROR_HANDLER);
 
         ReplaySubject<Frame> cachedResponses = captureResponses(conn);
         sendSetupFrame(conn);
@@ -230,7 +226,7 @@ public class ResponderTest
         Responder.create(conn, setup -> RequestHandler.create(
             null,
             request -> toPublisher(interval(1000, TimeUnit.MILLISECONDS, ts).map(i -> utf8EncodedPayload(i + "_" + byteToString(request.getData()), null))),
-            null, null), ERROR_HANDLER);
+            null, null), NULL_LEASE_GOVERNOR, ERROR_HANDLER);
 
         ReplaySubject<Frame> cachedResponses = captureResponses(conn);
         sendSetupFrame(conn);


### PR DESCRIPTION
A Requester who create a ReactiveSocket with the HONOR_LEASE bit, will now have
to wait for a LEASE from a server before beeing able to send any request.

I added some very simple lease distribution strategies for testing purposes,
they are nowhere near the one that we'll use in production.

I also refactored the unit-test to use JUnit Theory, which now test the
ReactiveSocket with multiple combinations of parameters.