### PR TITLE
Remove the check for valid from the Requester to the Responder.

### DIFF
--- a/src/main/java/io/reactivesocket/Frame.java
+++ b/src/main/java/io/reactivesocket/Frame.java
@@ -350,13 +350,13 @@ public class Frame implements Payload
 
     public static class Lease
     {
-        public static long ttl(final Frame frame)
+        public static int ttl(final Frame frame)
         {
             ensureFrameType(FrameType.LEASE, frame);
             return LeaseFrameFlyweight.ttl(frame.directBuffer, 0);
         }
 
-        public static long numberOfRequests(final Frame frame)
+        public static int numberOfRequests(final Frame frame)
         {
             ensureFrameType(FrameType.LEASE, frame);
             return LeaseFrameFlyweight.numRequests(frame.directBuffer, 0);

--- a/src/main/java/io/reactivesocket/LeaseGovernor.java
+++ b/src/main/java/io/reactivesocket/LeaseGovernor.java
@@ -6,7 +6,30 @@ public interface LeaseGovernor {
     public static final LeaseGovernor NULL_LEASE_GOVERNOR = new NullLeaseGovernor();
     public static final LeaseGovernor UNLIMITED_LEASE_GOVERNOR = new UnlimitedLeaseGovernor();
 
-    void register(Responder responder);
-    void unregister(Responder responder);
-    void notify(Responder responder, Frame requestFrame);
+    /**
+     * Register a responder into the LeaseGovernor.
+     * This give the responsibility to the leaseGovernor to send lease to the responder.
+     *
+     * @param responder the responder that will receive lease
+     */
+    public void register(Responder responder);
+
+    /**
+     * Unregister a responder from the LeaseGovernor.
+     * Depending on the implementation, this action may trigger a rebalancing of
+     * the tickets/window to the remaining responders.
+     * @param responder the responder to be removed
+     */
+    public void unregister(Responder responder);
+
+    /**
+     * Check if the message received by the responder is valid (i.e. received during a
+     * valid lease window)
+     * This action my have side effect in the LeaseGovernor.
+     *
+     * @param responder receiving the message
+     * @param frame the received frame
+     * @return
+     */
+    public boolean accept(Responder responder, Frame frame);
 }

--- a/src/main/java/io/reactivesocket/NullLeaseGovernor.java
+++ b/src/main/java/io/reactivesocket/NullLeaseGovernor.java
@@ -10,5 +10,7 @@ public class NullLeaseGovernor implements LeaseGovernor {
     public void unregister(Responder responder) {}
 
     @Override
-    public void notify(Responder responder, Frame requestFrame) {}
+    public boolean accept(Responder responder, Frame frame) {
+        return true;
+    }
 }

--- a/src/main/java/io/reactivesocket/ReactiveSocket.java
+++ b/src/main/java/io/reactivesocket/ReactiveSocket.java
@@ -95,7 +95,7 @@ public class ReactiveSocket implements AutoCloseable {
 	 *            (Optional) Callback for errors while processing streams over connection. If 'null' then error messages will be output to System.err.
 	 * @return ReactiveSocket for start, shutdown and sending requests.
 	 */
-	public static ReactiveSocket fromClientConnection(DuplexConnection connection, ConnectionSetupPayload setup, RequestHandler handler, LeaseGovernor leaseGovernor, Consumer<Throwable> errorStream) {
+	public static ReactiveSocket fromClientConnection(DuplexConnection connection, ConnectionSetupPayload setup, RequestHandler handler, Consumer<Throwable> errorStream) {
 		if(connection == null) {
 			throw new IllegalArgumentException("DuplexConnection can not be null");
 		}
@@ -104,7 +104,7 @@ public class ReactiveSocket implements AutoCloseable {
 		}
 		final RequestHandler h = handler != null ? handler : EMPTY_HANDLER;
 		Consumer<Throwable> es = errorStream != null ? errorStream : DEFAULT_ERROR_STREAM;
-		return new ReactiveSocket(connection, false, setup, s -> h, leaseGovernor, es);
+		return new ReactiveSocket(connection, false, setup, s -> h, LeaseGovernor.NULL_LEASE_GOVERNOR, es);
 	}
 
 	/**
@@ -125,11 +125,11 @@ public class ReactiveSocket implements AutoCloseable {
 	 * @return ReactiveSocket for start, shutdown and sending requests.
 	 */
 	public static ReactiveSocket fromClientConnection(DuplexConnection connection, ConnectionSetupPayload setup, Consumer<Throwable> errorStream) {
-		return fromClientConnection(connection, setup, EMPTY_HANDLER, LeaseGovernor.NULL_LEASE_GOVERNOR, errorStream);
+		return fromClientConnection(connection, setup, EMPTY_HANDLER, errorStream);
 	}
 
-	public static ReactiveSocket fromClientConnection(DuplexConnection connection, ConnectionSetupPayload setup, LeaseGovernor leaseGovernor) {
-		return fromClientConnection(connection, setup, EMPTY_HANDLER, leaseGovernor, DEFAULT_ERROR_STREAM);
+	public static ReactiveSocket fromClientConnection(DuplexConnection connection, ConnectionSetupPayload setup) {
+		return fromClientConnection(connection, setup, EMPTY_HANDLER, DEFAULT_ERROR_STREAM);
 	}
 
 	/**

--- a/src/main/java/io/reactivesocket/UnlimitedLeaseGovernor.java
+++ b/src/main/java/io/reactivesocket/UnlimitedLeaseGovernor.java
@@ -12,5 +12,7 @@ public class UnlimitedLeaseGovernor implements LeaseGovernor {
     public void unregister(Responder responder) {}
 
     @Override
-    public void notify(Responder responder, Frame requestFrame) {}
+    public boolean accept(Responder responder, Frame frame) {
+        return true;
+    }
 }

--- a/src/main/java/io/reactivesocket/exceptions/LeaseException.java
+++ b/src/main/java/io/reactivesocket/exceptions/LeaseException.java
@@ -18,4 +18,8 @@ package io.reactivesocket.exceptions;
 // TODO: optimize capture of callstack
 public class LeaseException extends Throwable implements NotSentException
 {
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
 }

--- a/src/main/java/io/reactivesocket/internal/LeaseFrameFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/LeaseFrameFlyweight.java
@@ -27,44 +27,44 @@ public class LeaseFrameFlyweight
 {
     // relative to start of passed offset
     private static final int TTL_FIELD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;
-    private static final int NUM_REQUESTS_FIELD_OFFSET = TTL_FIELD_OFFSET + BitUtil.SIZE_OF_LONG;
-    private static final int PAYLOAD_OFFSET = NUM_REQUESTS_FIELD_OFFSET + BitUtil.SIZE_OF_LONG;
+    private static final int NUM_REQUESTS_FIELD_OFFSET = TTL_FIELD_OFFSET + BitUtil.SIZE_OF_INT;
+    private static final int PAYLOAD_OFFSET = NUM_REQUESTS_FIELD_OFFSET + BitUtil.SIZE_OF_INT;
 
     public static int computeFrameLength(final int metadataLength)
     {
         int length = FrameHeaderFlyweight.computeFrameHeaderLength(FrameType.SETUP, metadataLength, 0);
 
-        return length + BitUtil.SIZE_OF_LONG * 2;
+        return length + BitUtil.SIZE_OF_INT * 2;
     }
 
     public static int encode(
         final MutableDirectBuffer mutableDirectBuffer,
         final int offset,
-        final long ttl,
-        final long numRequests,
+        final int ttl,
+        final int numRequests,
         final ByteBuffer metadata)
     {
         final int frameLength = computeFrameLength(metadata.capacity());
 
         int length = FrameHeaderFlyweight.encodeFrameHeader(mutableDirectBuffer, offset, frameLength, 0, FrameType.LEASE, 0);
 
-        mutableDirectBuffer.putLong(offset + TTL_FIELD_OFFSET, ttl, ByteOrder.BIG_ENDIAN);
-        mutableDirectBuffer.putLong(offset + NUM_REQUESTS_FIELD_OFFSET, numRequests, ByteOrder.BIG_ENDIAN);
+        mutableDirectBuffer.putInt(offset + TTL_FIELD_OFFSET, ttl, ByteOrder.BIG_ENDIAN);
+        mutableDirectBuffer.putInt(offset + NUM_REQUESTS_FIELD_OFFSET, numRequests, ByteOrder.BIG_ENDIAN);
 
-        length += BitUtil.SIZE_OF_LONG * 2;
+        length += BitUtil.SIZE_OF_INT * 2;
         length += FrameHeaderFlyweight.encodeMetadata(mutableDirectBuffer, offset, offset + length, metadata);
 
         return length;
     }
 
-    public static long ttl(final DirectBuffer directBuffer, final int offset)
+    public static int ttl(final DirectBuffer directBuffer, final int offset)
     {
-        return directBuffer.getLong(offset + TTL_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
+        return directBuffer.getInt(offset + TTL_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
-    public static long numRequests(final DirectBuffer directBuffer, final int offset)
+    public static int numRequests(final DirectBuffer directBuffer, final int offset)
     {
-        return directBuffer.getLong(offset + NUM_REQUESTS_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
+        return directBuffer.getInt(offset + NUM_REQUESTS_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
     public static int payloadOffset(final DirectBuffer directBuffer, final int offset)

--- a/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/src/main/java/io/reactivesocket/internal/Requester.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import io.reactivesocket.exceptions.LeaseException;
+import io.reactivesocket.exceptions.NotSentException;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -47,14 +48,15 @@ import uk.co.real_logic.agrona.collections.Long2ObjectHashMap;
 public class Requester {
 
 	private final static Subscription CANCELLED = new EmptySubscription();
+	private final static long epoch = System.nanoTime();
 
 	private final boolean isServer;
 	private final DuplexConnection connection;
 	private final Long2ObjectHashMap<UnicastSubject<Frame>> streamInputMap = new Long2ObjectHashMap<>();
 	private final ConnectionSetupPayload setupPayload;
 	private final Consumer<Throwable> errorStream;
-	private final boolean honorLease;
 
+	private final boolean honorLease;
 	private long ttlExpiration;
 	private long numberOfRemainingRequests = 0;
 	private int streamCount = 0; // 0 is reserved for setup, all normal messages are >= 1
@@ -139,16 +141,7 @@ public class Requester {
 					public void request(long n) {
 						if (!started && n > 0) {
 							started = true;
-
-							// does lease allow for sending request
-							if (!canRequest())
-							{
-								child.onError(new LeaseException());
-							}
-							else
-							{
-								numberOfRemainingRequests--;
-							}
+							numberOfRemainingRequests--;
 
 							connection.addOutput(PublisherUtils.just(Frame.fromRequest(nextStreamId(), FrameType.FIRE_AND_FORGET, payload, 0)), new Completable() {
 
@@ -202,9 +195,16 @@ public class Requester {
 	 *
 	 * @return
 	 */
-	public double availability()
-	{
-		return (canRequest() ? 1.0 : 0.0);
+	public double availability() {
+		if (!honorLease) {
+			return 1.0;
+		}
+		final long now = System.currentTimeMillis();
+		double available = 0.0;
+		if (numberOfRemainingRequests > 0 && (now < ttlExpiration)) {
+			available = 1.0;
+		}
+		return available;
 	}
 
 	/**
@@ -281,24 +281,16 @@ public class Requester {
 						
 						// declare output to transport
 						writer = UnicastSubject.create((w, rn) -> {
-							// does lease allow for sending request
-							if (!canRequest())
-							{
-								w.onError(new LeaseException());
-							}
-							else
-							{
-								numberOfRemainingRequests--;
-							}
+							numberOfRemainingRequests--;
 
 							// decrement as we request it
 							requested.addAndGet(-requestN);
 							// record how many we have requested
 							outstanding.addAndGet(requestN);
-							
+
 							// when transport connects we write the request frame for this stream
 							if (payload != null) {
-								w.onNext(Frame.fromRequest(streamId, type, payload, (int)requestN));
+								w.onNext(Frame.fromRequest(streamId, type, payload, (int) requestN));
 							} else {
 								// TODO hook this in via addOutput so requestN flows through correctly
 //								connection.addOutput(payloads.map(p -> ... convert things to Frame here ...), new Completable()
@@ -329,7 +321,7 @@ public class Requester {
 
 									@Override
 									public void onNext(Payload p) {
-										w.onNext(Frame.fromRequest(streamId, type, p, (int)requestN));
+										w.onNext(Frame.fromRequest(streamId, type, p, (int) requestN));
 									}
 
 									@Override
@@ -346,9 +338,8 @@ public class Requester {
 
 								});
 							}
-
 						});
-						
+
 						// Response frames for this Stream
 						UnicastSubject<Frame> transportInputSubject = UnicastSubject.create();
 						synchronized(Requester.this) {
@@ -372,7 +363,9 @@ public class Requester {
 							@Override
 							public void error(Throwable e) {
 								child.onError(e);
-								cancel();
+								if (!(e instanceof NotSentException)) {
+									cancel();
+								}
 							}
 
 						});
@@ -382,7 +375,6 @@ public class Requester {
 						final long requestThreshold = REQUEST_THRESHOLD < currentN ? REQUEST_THRESHOLD : currentN/3;
 						requestIfNecessary(streamId, requestThreshold, currentN, outstanding.get(), writer, requested, outstanding);
 					}
-
 				}
 
 				@Override
@@ -436,12 +428,10 @@ public class Requester {
 						
 						Publisher<Frame> requestOutput = PublisherUtils.just(Frame.fromRequest(streamId, type, payload, 1));
 						// connect to transport
-						connection.addOutput(requestOutput, new Completable()
-						{
+						connection.addOutput(requestOutput, new Completable() {
 
 							@Override
-							public void success()
-							{
+							public void success() {
 								// nothing to do onSuccess
 							}
 
@@ -453,18 +443,15 @@ public class Requester {
 
 						});
 					}
-
 				}
 
 				@Override
 				public void cancel() {
 					if (!streamInputSubscriber.terminated.get()) {
-						connection.addOutput(PublisherUtils.just(Frame.from(streamId, FrameType.CANCEL)), new Completable()
-						{
+						connection.addOutput(PublisherUtils.just(Frame.from(streamId, FrameType.CANCEL)), new Completable() {
 
 							@Override
-							public void success()
-							{
+							public void success() {
 								// nothing to do onSuccess
 							}
 
@@ -619,9 +606,10 @@ public class Requester {
 						onError(new SetupException(frame));
 					} else if (FrameType.LEASE.equals(frame.getType()) && honorLease) {
 						numberOfRemainingRequests = Frame.Lease.numberOfRequests(frame);
-						final long now = System.nanoTime();
-						final long ttl = Frame.Lease.ttl(frame);
-						if (Long.MAX_VALUE - ttl < now) {
+						final long now = System.currentTimeMillis();
+						final int ttl = Frame.Lease.ttl(frame);
+						if (ttl == Integer.MAX_VALUE) {
+							// Integer.MAX_VALUE represents infinity
 							ttlExpiration = Long.MAX_VALUE;
 						} else {
 							ttlExpiration = now + ttl;
@@ -691,22 +679,5 @@ public class Requester {
 		final byte[] bytes = new byte[bb.capacity()];
 		bb.get(bytes);
 		return new String(bytes, Charset.forName("UTF-8"));
-	}
-
-	private boolean canRequest()
-	{
-		boolean result = false;
-		final long now = System.nanoTime();
-
-		if (!honorLease)
-		{
-			result = true;
-		}
-		else if (numberOfRemainingRequests > 0 && (now < ttlExpiration))
-		{
-			result = true;
-		}
-
-		return result;
 	}
 }

--- a/src/main/java/io/reactivesocket/internal/Responder.java
+++ b/src/main/java/io/reactivesocket/internal/Responder.java
@@ -38,8 +38,8 @@ import uk.co.real_logic.agrona.collections.Long2ObjectHashMap;
 public class Responder {
 	private final DuplexConnection connection;
 	private final ConnectionSetupHandler connectionHandler;
-	private final LeaseGovernor leaseGovernor;
 	private final Consumer<Throwable> errorStream;
+	private LeaseGovernor leaseGovernor;
 
 	private Responder(DuplexConnection connection, ConnectionSetupHandler connectionHandler, LeaseGovernor leaseGovernor, Consumer<Throwable> errorStream) {
 		this.connection = connection;
@@ -127,11 +127,12 @@ public class Responder {
 							setupErrorAndTearDown(connection, new SetupException(SetupErrorCode.REJECTED, e));
 						}
 
-						// the L bit set must wait until the application logic explicitly sends a LEASE. ConnectionSetupPlayload
-						// knows of bits being set.
+						// the L bit set must wait until the application logic explicitly sends
+						// a LEASE. ConnectionSetupPlayload knows of bits being set.
 						if (connectionSetupPayload.willClientHonorLease()) {
 							leaseGovernor.register(Responder.this);
-							leaseGovernor.notify(Responder.this, requestFrame);
+						} else {
+							leaseGovernor = LeaseGovernor.UNLIMITED_LEASE_GOVERNOR;
 						}
 
 						// TODO: handle keepalive logic here
@@ -139,46 +140,50 @@ public class Responder {
 						setupErrorAndTearDown(connection, new SetupException(SetupErrorCode.INVALID_SETUP, "Setup frame missing"));
 					}
 				} else {
-					leaseGovernor.notify(Responder.this, requestFrame);
 					Publisher<Frame> responsePublisher = null;
-					try {
-						if (requestFrame.getType() == FrameType.REQUEST_RESPONSE) {
-							responsePublisher = handleRequestResponse(requestFrame, requestHandler, cancellationSubscriptions);
-						} else if (requestFrame.getType() == FrameType.REQUEST_STREAM) {
-							responsePublisher = handleRequestStream(requestFrame, requestHandler, cancellationSubscriptions, inFlight);
-						} else if (requestFrame.getType() == FrameType.FIRE_AND_FORGET) {
-							responsePublisher = handleFireAndForget(requestFrame, requestHandler);
-						} else if (requestFrame.getType() == FrameType.REQUEST_SUBSCRIPTION) {
-							responsePublisher = handleRequestSubscription(requestFrame, requestHandler, cancellationSubscriptions, inFlight);
-						} else if (requestFrame.getType() == FrameType.REQUEST_CHANNEL) {
-							responsePublisher = handleRequestChannel(requestFrame, requestHandler, channels, cancellationSubscriptions, inFlight);
-						} else if (requestFrame.getType() == FrameType.CANCEL) {
-							Subscription s = null;
-							synchronized(Responder.this) {
-								s = cancellationSubscriptions.get(requestFrame.getStreamId());
-							}
-							if (s != null) {
-								s.cancel();
-							}
-							return;
-						} else if (requestFrame.getType() == FrameType.REQUEST_N) {
-							Subscription inFlightSubscription = null;
-							synchronized(Responder.this) {
-								inFlightSubscription = inFlight.get(requestFrame.getStreamId());
-							}
-							if(inFlightSubscription != null) {
-								inFlightSubscription.request(Frame.RequestN.requestN(requestFrame));
+					if (leaseGovernor.accept(Responder.this, requestFrame)) {
+						try {
+							if (requestFrame.getType() == FrameType.REQUEST_RESPONSE) {
+								responsePublisher = handleRequestResponse(requestFrame, requestHandler, cancellationSubscriptions);
+							} else if (requestFrame.getType() == FrameType.REQUEST_STREAM) {
+								responsePublisher = handleRequestStream(requestFrame, requestHandler, cancellationSubscriptions, inFlight);
+							} else if (requestFrame.getType() == FrameType.FIRE_AND_FORGET) {
+								responsePublisher = handleFireAndForget(requestFrame, requestHandler);
+							} else if (requestFrame.getType() == FrameType.REQUEST_SUBSCRIPTION) {
+								responsePublisher = handleRequestSubscription(requestFrame, requestHandler, cancellationSubscriptions, inFlight);
+							} else if (requestFrame.getType() == FrameType.REQUEST_CHANNEL) {
+								responsePublisher = handleRequestChannel(requestFrame, requestHandler, channels, cancellationSubscriptions, inFlight);
+							} else if (requestFrame.getType() == FrameType.CANCEL) {
+								Subscription s = null;
+								synchronized (Responder.this) {
+									s = cancellationSubscriptions.get(requestFrame.getStreamId());
+								}
+								if (s != null) {
+									s.cancel();
+								}
 								return;
+							} else if (requestFrame.getType() == FrameType.REQUEST_N) {
+								Subscription inFlightSubscription = null;
+								synchronized (Responder.this) {
+									inFlightSubscription = inFlight.get(requestFrame.getStreamId());
+								}
+								if (inFlightSubscription != null) {
+									inFlightSubscription.request(Frame.RequestN.requestN(requestFrame));
+									return;
+								}
+								// TODO should we do anything if we don't find the stream? emitting an error is risky as the responder could have terminated and cleaned up already
+							} else {
+								responsePublisher = PublisherUtils.errorFrame(streamId, new IllegalStateException("Unexpected prefix: " + requestFrame.getType()));
 							}
-							// TODO should we do anything if we don't find the stream? emitting an error is risky as the responder could have terminated and cleaned up already
-						} else {
-							responsePublisher = PublisherUtils.errorFrame(streamId, new IllegalStateException("Unexpected prefix: " + requestFrame.getType()));
+						} catch (Throwable e) {
+							// synchronous try/catch since we execute user functions in the handlers and they could throw
+							errorStream.accept(new RuntimeException("Error in request handling.", e));
+							// error message to user
+							responsePublisher = PublisherUtils.errorFrame(streamId, new RuntimeException("Unhandled error processing request"));
 						}
-					} catch (Throwable e) {
-						// synchronous try/catch since we execute user functions in the handlers and they could throw
-						errorStream.accept(new RuntimeException("Error in request handling.", e));
-						// error message to user
-						responsePublisher = PublisherUtils.errorFrame(streamId, new RuntimeException("Unhandled error processing request"));
+					} else {
+//						responsePublisher = PublisherUtils.errorFrame(streamId, new LeaseException());
+						responsePublisher = PublisherUtils.errorFrame(streamId, new RuntimeException("Lease Exception"));
 					}
 					connection.addOutput(responsePublisher, new Completable() {
 

--- a/src/test/java/io/reactivesocket/FrameTest.java
+++ b/src/test/java/io/reactivesocket/FrameTest.java
@@ -393,7 +393,7 @@ public class FrameTest
     @Test
     public void shouldFormCorrectlyWithoutMetadataForLease()
     {
-        final int ttl = (int)TimeUnit.SECONDS.toNanos(8);
+        final int ttl = (int)TimeUnit.SECONDS.toMillis(8);
         final int numberOfRequests = 16;
         final Frame f = Frame.fromLease(ttl, numberOfRequests, Frame.NULL_BYTEBUFFER);
 
@@ -408,7 +408,7 @@ public class FrameTest
     @Test
     public void shouldFormCorrectlyWithMetadataForLease()
     {
-        final int ttl = (int)TimeUnit.SECONDS.toNanos(8);
+        final int ttl = (int)TimeUnit.SECONDS.toMillis(8);
         final int numberOfRequests = 16;
         final ByteBuffer leaseMetadata = TestUtil.byteBufferFromUtf8String("lease metadata");
 

--- a/src/test/java/io/reactivesocket/LeaseTest.java
+++ b/src/test/java/io/reactivesocket/LeaseTest.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivesocket;
+
+import io.reactivesocket.internal.Responder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import rx.observers.TestSubscriber;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.reactivesocket.TestUtil.byteToString;
+import static io.reactivesocket.TestUtil.utf8EncodedPayload;
+import static io.reactivesocket.ConnectionSetupPayload.HONOR_LEASE;
+
+import static org.junit.Assert.assertTrue;
+import static rx.Observable.*;
+import static rx.Observable.empty;
+import static rx.RxReactiveStreams.toObservable;
+import static rx.RxReactiveStreams.toPublisher;
+
+public class LeaseTest {
+    private TestConnection clientConnection;
+    private ReactiveSocket socketServer;
+    private ReactiveSocket socketClient;
+    private TestingLeaseGovernor leaseGovernor;
+
+    private class TestingLeaseGovernor implements LeaseGovernor {
+        private volatile Responder responder;
+        private volatile long ttlExpiration;
+        private volatile int grantedTickets;
+
+        @Override
+        public synchronized void register(Responder responder) {
+            this.responder = responder;
+        }
+
+        @Override
+        public synchronized void unregister(Responder responder) {
+            responder = null;
+        }
+
+        @Override
+        public synchronized boolean accept(Responder responder, Frame frame) {
+            boolean valid = grantedTickets > 0
+                && ttlExpiration >= System.currentTimeMillis();
+            grantedTickets--;
+            return valid;
+        }
+
+        public synchronized void distribute(int ttlMs, int tickets) {
+            if (responder == null) {
+                throw new IllegalStateException("responder is null");
+            }
+            ttlExpiration = System.currentTimeMillis() + ttlMs;
+            grantedTickets = tickets;
+            responder.sendLease(ttlMs, tickets);
+        }
+    }
+
+    @Before
+    public void setup() {
+        TestConnection serverConnection = new TestConnection();
+        clientConnection = new TestConnection();
+        clientConnection.connectToServerConnection(serverConnection);
+        leaseGovernor = new TestingLeaseGovernor();
+
+        socketServer = ReactiveSocket.fromServerConnection(
+            serverConnection, setup -> new RequestHandler() {
+
+            @Override
+            public Publisher<Payload> handleRequestResponse(Payload payload) {
+                return toPublisher(just(utf8EncodedPayload("hello world", null)));
+            }
+
+            @Override
+            public Publisher<Payload> handleRequestStream(Payload payload) {
+                return toPublisher(
+                    range(0, 100)
+                        .map(i -> "hello world " + i)
+                        .map(n -> utf8EncodedPayload(n, null))
+                );
+            }
+
+            @Override
+            public Publisher<Payload> handleSubscription(Payload payload) {
+                return toPublisher(interval(1, TimeUnit.MICROSECONDS)
+                    .map(i -> "subscription " + i)
+                    .map(n -> utf8EncodedPayload(n, null)));
+            }
+
+            @Override
+            public Publisher<Void> handleFireAndForget(Payload payload) {
+                return toPublisher(empty());
+            }
+
+            /**
+             * Use Payload.metadata for routing
+             */
+            @Override
+            public Publisher<Payload> handleChannel(
+                Payload initialPayload,
+                Publisher<Payload> payloads
+            ) {
+                return toPublisher(toObservable(payloads).map(p -> {
+                    return utf8EncodedPayload(byteToString(p.getData()) + "_echo", null);
+                }));
+            }
+        }, leaseGovernor, t -> {});
+
+        socketClient = ReactiveSocket.fromClientConnection(
+            clientConnection,
+            ConnectionSetupPayload.create("UTF-8", "UTF-8", HONOR_LEASE)
+        );
+
+        // start both the server and client and monitor for errors
+        socketServer.start();
+        socketClient.start();
+
+    }
+
+    @After
+    public void shutdown() {
+        socketServer.shutdown();
+        socketClient.shutdown();
+    }
+
+    @Test
+    public void testWriteWithoutLease() throws InterruptedException {
+        // initially client doesn't have any availability
+        assertTrue(socketClient.availability() == 0.0);
+        Thread.sleep(100);
+        assertTrue(socketClient.availability() == 0.0);
+
+        // the first call will fail without a valid lease
+        Publisher<Payload> response0 = socketClient.requestResponse(
+            TestUtil.utf8EncodedPayload("hello", null));
+        TestSubscriber<Payload> ts0 = TestSubscriber.create();
+        toObservable(response0).subscribe(ts0);
+        ts0.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        ts0.assertError(RuntimeException.class);
+
+        // send a Lease(10 sec, 1 message), and wait for the availability on the client side
+        leaseGovernor.distribute(10_000, 1);
+        awaitSocketAvailabilityChange(socketClient, 1.0, 10, TimeUnit.SECONDS);
+
+        // the second call will succeed
+        Publisher<Payload> response1 = socketClient.requestResponse(
+            TestUtil.utf8EncodedPayload("hello", null));
+        TestSubscriber<Payload> ts1 = TestSubscriber.create();
+        toObservable(response1).subscribe(ts1);
+        ts1.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        ts1.assertNoErrors();
+        ts1.assertValue(TestUtil.utf8EncodedPayload("hello world", null));
+
+        // the client consumed all its ticket, next call will fail
+        // (even though the window is still ok)
+        Publisher<Payload> response2 = socketClient.requestResponse(
+            TestUtil.utf8EncodedPayload("hello", null));
+        TestSubscriber<Payload> ts2 = TestSubscriber.create();
+        toObservable(response2).subscribe(ts2);
+        ts2.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        ts2.assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void testLeaseOverwrite() throws InterruptedException {
+        assertTrue(socketClient.availability() == 0.0);
+        Thread.sleep(100);
+        assertTrue(socketClient.availability() == 0.0);
+
+        leaseGovernor.distribute(10_000, 100);
+        awaitSocketAvailabilityChange(socketClient, 1.0, 10, TimeUnit.SECONDS);
+
+        leaseGovernor.distribute(10_000, 0);
+        awaitSocketAvailabilityChange(socketClient, 0.0, 10, TimeUnit.SECONDS);
+    }
+
+    private void awaitSocketAvailabilityChange(
+        ReactiveSocket socket,
+        double expected,
+        long timeout,
+        TimeUnit unit
+    ) throws InterruptedException {
+        long waitTimeMs = 1L;
+        long startTime = System.nanoTime();
+        long timeoutNanos = TimeUnit.NANOSECONDS.convert(timeout, unit);
+
+        while (socket.availability() != expected) {
+            System.out.println("waiting for availability");
+            Thread.sleep(waitTimeMs);
+            waitTimeMs = Math.min(waitTimeMs * 2, 1000L);
+            final long elapsedNanos = System.nanoTime() - startTime;
+            if (elapsedNanos > timeoutNanos) {
+                throw new IllegalStateException("Timeout while waiting for socket availability");
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivesocket/ReactiveSocketTest.java
+++ b/src/test/java/io/reactivesocket/ReactiveSocketTest.java
@@ -133,7 +133,8 @@ public class ReactiveSocketTest {
 				}));
 			}
 
-		}, LeaseGovernor.UNLIMITED_LEASE_GOVERNOR, t -> {
+//		}, LeaseGovernor.UNLIMITED_LEASE_GOVERNOR, t -> {
+		}, new FairLeaseGovernor(100, 10L, TimeUnit.SECONDS), t -> {
 			lastServerError.set(t);
 			lastServerErrorCountDown.countDown();
 		});
@@ -153,12 +154,10 @@ public class ReactiveSocketTest {
 		}
 		socketClient = ReactiveSocket.fromClientConnection(
 			clientConnection,
-			ConnectionSetupPayload.create("UTF-8", "UTF-8", setupFlag),
-			new FairLeaseGovernor(100, 5, TimeUnit.SECONDS)
+			ConnectionSetupPayload.create("UTF-8", "UTF-8", setupFlag)
 		);
 
 		// start both the server and client and monitor for errors
-		//socketServer.start(LeaseGovernor.UNLIMITED_LEASE_GOVERNOR);
 		socketServer.start();
 		socketClient.start();
 


### PR DESCRIPTION
This allow to have implementation of the Requester that still send
message even outside of a valid lease (not recommended, but it could
be useful in specific case like full cluster down).

Lease TTL and Tickets have been converted to 32bits + the time
unit is now millisecond.