### PR TITLE
Thread Safety

### DIFF
--- a/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/src/main/java/io/reactivesocket/internal/Requester.java
@@ -391,7 +391,7 @@ public class Requester {
 								public void subscribe(Subscriber<? super Frame> transport) {
 									transport.onSubscribe(new Subscription() {
 
-										AtomicBoolean started = new AtomicBoolean(false);
+										final AtomicBoolean started = new AtomicBoolean(false);
 										@Override
 										public void request(long n) {
 											if(n <= 0) {

--- a/src/test/java/io/reactivesocket/RequesterResponderInteractionTest.java
+++ b/src/test/java/io/reactivesocket/RequesterResponderInteractionTest.java
@@ -15,11 +15,10 @@
  */
 package io.reactivesocket;
 
-import static io.reactivesocket.LeaseGovernor.NULL_LEASE_GOVERNOR;
-import static org.junit.Assert.assertEquals;
+import static io.reactivesocket.LeaseGovernor.*;
 import static io.reactivex.Observable.*;
+import static org.junit.Assert.*;
 
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -31,9 +30,8 @@ import io.reactivesocket.internal.Requester;
 import io.reactivesocket.internal.Responder;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.schedulers.Schedulers;
-import uk.co.real_logic.agrona.collections.Long2ObjectHashMap;
+import io.reactivex.subscribers.TestSubscriber;
 
 public class RequesterResponderInteractionTest
 {
@@ -128,7 +126,7 @@ public class RequesterResponderInteractionTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testRequestResponseSuccess() {
         TestSubscriber<Payload> ts = new TestSubscriber<>();
         requester.requestResponse(TestUtil.utf8EncodedPayload("hello", null)).subscribe(ts);
@@ -137,7 +135,7 @@ public class RequesterResponderInteractionTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testRequestResponseError() {
         TestSubscriber<Payload> ts = new TestSubscriber<>();
         requester.requestResponse(TestUtil.utf8EncodedPayload("doesntExist", null)).subscribe(ts);
@@ -147,7 +145,7 @@ public class RequesterResponderInteractionTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testRequestStreamSuccess() {
         TestSubscriber<Payload> ts = new TestSubscriber<>();
         requester.requestStream(TestUtil.utf8EncodedPayload("range", null)).subscribe(ts);
@@ -156,7 +154,7 @@ public class RequesterResponderInteractionTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testRequestStreamError() {
         TestSubscriber<Payload> ts = new TestSubscriber<>();
         requester.requestStream(TestUtil.utf8EncodedPayload("doesntExist", null)).subscribe(ts);
@@ -166,7 +164,7 @@ public class RequesterResponderInteractionTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testRequestSubscriptionSuccess() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(3);
         TestSubscriber<Payload> ts = new TestSubscriber<>(new Observer<Payload>() {
@@ -196,7 +194,7 @@ public class RequesterResponderInteractionTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testRequestSubscriptionErrorOnCompletion() {
         TestSubscriber<Payload> ts = new TestSubscriber<>();
         requester.requestSubscription(TestUtil.utf8EncodedPayload("rangeThatCompletes", null)).subscribe(ts);
@@ -207,7 +205,7 @@ public class RequesterResponderInteractionTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testRequestSubscriptionError() {
         TestSubscriber<Payload> ts = new TestSubscriber<>();
         requester.requestStream(TestUtil.utf8EncodedPayload("doesntExist", null)).subscribe(ts);
@@ -217,7 +215,7 @@ public class RequesterResponderInteractionTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testFireAndForgetSuccess() {
         TestSubscriber<Void> ts = new TestSubscriber<>();
         requester.fireAndForget(TestUtil.utf8EncodedPayload("hello", null)).subscribe(ts);
@@ -228,7 +226,7 @@ public class RequesterResponderInteractionTest
 
     // this is testing that the client is completely unaware of server-side errors
     @Ignore
-    @Test
+    @Test(timeout=2000)
     public void testFireAndForgetError() {
         TestSubscriber<Void> ts = new TestSubscriber<>();
         requester.fireAndForget(TestUtil.utf8EncodedPayload("doesntExist", null)).subscribe(ts);

--- a/src/test/java/io/reactivesocket/TestFlowControlRequestN.java
+++ b/src/test/java/io/reactivesocket/TestFlowControlRequestN.java
@@ -188,7 +188,7 @@ public class TestFlowControlRequestN {
 	 * Test that the upstream is governed by request(n)
 	 * @throws InterruptedException 
 	 */
-	@Test
+	@Test(timeout=2000)
 	public void testRequestChannel_batches_upstream_echo() throws InterruptedException {
 		ControlledSubscriber s = new ControlledSubscriber();
 		AtomicInteger emittedClient = new AtomicInteger();
@@ -221,7 +221,7 @@ public class TestFlowControlRequestN {
 	 * Test that the upstream is governed by request(n)
 	 * @throws InterruptedException 
 	 */
-	@Test
+	@Test(timeout=2000)
 	public void testRequestChannel_batches_upstream_decoupled() throws InterruptedException {
 		ControlledSubscriber s = new ControlledSubscriber();
 		AtomicInteger emittedClient = new AtomicInteger();

--- a/src/test/java/io/reactivesocket/internal/RequesterTest.java
+++ b/src/test/java/io/reactivesocket/internal/RequesterTest.java
@@ -40,7 +40,7 @@ public class RequesterTest
 {
 	final static Consumer<Throwable> ERROR_HANDLER = Throwable::printStackTrace;
 	
-    @Test
+	@Test(timeout=2000)
     public void testRequestResponseSuccess() {
         TestConnection conn = establishConnection();
         ReplaySubject<Frame> requests = captureRequests(conn);
@@ -71,7 +71,7 @@ public class RequesterTest
         ts.assertComplete();
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testRequestResponseError() {
         TestConnection conn = establishConnection();
         ReplaySubject<Frame> requests = captureRequests(conn);
@@ -99,7 +99,7 @@ public class RequesterTest
         assertEquals("Failed", ts.errors().get(0).getMessage());
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testRequestResponseCancel() {
         TestConnection conn = establishConnection();
         ReplaySubject<Frame> requests = captureRequests(conn);
@@ -132,7 +132,7 @@ public class RequesterTest
     }
 
     // TODO REQUEST_N on initial frame not implemented yet
-    @Test
+	@Test(timeout=2000)
     public void testRequestStreamSuccess() {
         TestConnection conn = establishConnection();
         ReplaySubject<Frame> requests = captureRequests(conn);
@@ -166,7 +166,7 @@ public class RequesterTest
     }
 
  // TODO REQUEST_N on initial frame not implemented yet
-    @Test
+	@Test(timeout=2000)
     public void testRequestStreamSuccessTake2AndCancel() {
         TestConnection conn = establishConnection();
         ReplaySubject<Frame> requests = captureRequests(conn);
@@ -207,7 +207,7 @@ public class RequesterTest
         assertEquals(FrameType.CANCEL, three.getType());
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testRequestStreamError() {
         TestConnection conn = establishConnection();
         ReplaySubject<Frame> requests = captureRequests(conn);

--- a/src/test/java/io/reactivesocket/internal/ResponderTest.java
+++ b/src/test/java/io/reactivesocket/internal/ResponderTest.java
@@ -41,7 +41,7 @@ public class ResponderTest
 {
 	final static Consumer<Throwable> ERROR_HANDLER = Throwable::printStackTrace;
 	
-    @Test
+	@Test(timeout=2000)
     public void testRequestResponseSuccess() {
     	TestConnection conn = establishConnection();
         Responder.create(conn, setup -> new RequestHandler.Builder()
@@ -65,7 +65,7 @@ public class ResponderTest
         assertEquals("hello world", byteToString(first.getData()));
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testRequestResponseError() {
     	TestConnection conn = establishConnection();
         Responder.create(conn, setup -> new RequestHandler.Builder()
@@ -85,12 +85,12 @@ public class ResponderTest
         assertEquals("Request Not Found", byteToString(first.getData()));
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testRequestResponseCancel() {
         AtomicBoolean unsubscribed = new AtomicBoolean();
         Observable<Payload> delayed = never()
                 .cast(Payload.class)
-                .doOnUnsubscribe(() -> unsubscribed.set(true));
+                .doOnCancel(() -> unsubscribed.set(true));
 
         TestConnection conn = establishConnection();
         Responder.create(conn, setup -> new RequestHandler.Builder()
@@ -110,7 +110,7 @@ public class ResponderTest
         assertTrue(unsubscribed.get());
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testRequestStreamSuccess() {
     	TestConnection conn = establishConnection();
         Responder.create(conn, setup -> new RequestHandler.Builder()
@@ -141,7 +141,7 @@ public class ResponderTest
         assertEquals("", byteToString(frames.get(10).getData()));
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testRequestStreamError() {
     	TestConnection conn = establishConnection();
         Responder.create(conn, setup -> new RequestHandler.Builder()
@@ -173,7 +173,7 @@ public class ResponderTest
         assertEquals("Error Occurred!", byteToString(frames.get(3).getData()));
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testRequestStreamCancel() {
     	TestConnection conn = establishConnection();
         TestScheduler ts = Schedulers.test();
@@ -212,7 +212,7 @@ public class ResponderTest
         }
     }
 
-    @Test
+	@Test(timeout=2000)
     public void testMultiplexedStreams() {
         TestScheduler ts = Schedulers.test();
         TestConnection conn = establishConnection();

--- a/src/test/java/io/reactivesocket/internal/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivesocket/internal/UnicastSubjectTest.java
@@ -28,7 +28,7 @@ public class UnicastSubjectTest {
 	@Test
 	public void testSubscribeReceiveValue() {
 		Frame f = TestUtil.utf8EncodedResponseFrame(1, FrameType.NEXT_COMPLETE, "response");
-		UnicastSubject us = UnicastSubject.create();
+		UnicastSubject<Frame> us = UnicastSubject.create();
 		TestSubscriber<Frame> ts = new TestSubscriber<>();
 		us.subscribe(ts);
 		us.onNext(f);
@@ -39,13 +39,13 @@ public class UnicastSubjectTest {
 	@Test(expected = NullPointerException.class)
 	public void testNullPointerSendingWithoutSubscriber() {
 		Frame f = TestUtil.utf8EncodedResponseFrame(1, FrameType.NEXT_COMPLETE, "response");
-		UnicastSubject us = UnicastSubject.create();
+		UnicastSubject<Frame> us = UnicastSubject.create();
 		us.onNext(f);
 	}
 
 	@Test
 	public void testIllegalStateIfMultiSubscribe() {
-		UnicastSubject us = UnicastSubject.create();
+		UnicastSubject<Frame> us = UnicastSubject.create();
 		TestSubscriber<Frame> f1 = new TestSubscriber<>();
 		us.subscribe(f1);
 		TestSubscriber<Frame> f2 = new TestSubscriber<>();


### PR DESCRIPTION
Making `request(n)` behavior thread-safe with the use of `compareAndSet` and making mutable references `volatile`. 