### PR TITLE
DuplexConnection.getInput as Observable

### DIFF
--- a/src/main/java/io/reactivesocket/internal/EmptyDisposable.java
+++ b/src/main/java/io/reactivesocket/internal/EmptyDisposable.java
@@ -1,34 +1,31 @@
 /**
  * Copyright 2015 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.reactivesocket;
+package io.reactivesocket.internal;
 
-import java.io.Closeable;
+import io.reactivesocket.observable.Disposable;
 
-import org.reactivestreams.Publisher;
-
-import io.reactivesocket.observable.Observable;
-
-/**
- * Represents a connection with input/output that the protocol uses. 
- */
-public interface DuplexConnection extends Closeable {
-    // TODO should we call this 'Connection'? 'SocketConnection'? 'ReactiveSocketConnection'?
-
-	Observable<Frame> getInput();
-
-	void addOutput(Publisher<Frame> o, Completable callback);
+public class EmptyDisposable implements Disposable
+{
+	public static EmptyDisposable EMPTY = new EmptyDisposable(); 
 	
+    public void dispose()
+    {
+    }
+    
+    public boolean isDisposed() {
+    	return false;
+    }
 }

--- a/src/main/java/io/reactivesocket/observable/Disposable.java
+++ b/src/main/java/io/reactivesocket/observable/Disposable.java
@@ -1,0 +1,7 @@
+package io.reactivesocket.observable;
+
+public interface Disposable {
+
+	public void dispose();
+	
+}

--- a/src/main/java/io/reactivesocket/observable/Observable.java
+++ b/src/main/java/io/reactivesocket/observable/Observable.java
@@ -1,0 +1,6 @@
+package io.reactivesocket.observable;
+
+public interface Observable<T> {
+
+	public void subscribe(Observer<T> o);
+}

--- a/src/main/java/io/reactivesocket/observable/Observer.java
+++ b/src/main/java/io/reactivesocket/observable/Observer.java
@@ -1,0 +1,12 @@
+package io.reactivesocket.observable;
+
+public interface Observer<T> {
+
+	public void onNext(T t);
+	
+	public void onError(Throwable e);
+	
+	public void onComplete();
+	
+	public void onSubscribe(Disposable d);
+}

--- a/src/main/java/io/reactivesocket/observable/README.md
+++ b/src/main/java/io/reactivesocket/observable/README.md
@@ -1,0 +1,3 @@
+Interfaces for `Observable` that does not support backpressure.
+
+TODO: Decide if we just use concrete types from RxJava 2 once this type exists. (Flowable vs Observable)

--- a/src/perf/java/io/reactivesocket/perfutil/PerfTestConnection.java
+++ b/src/perf/java/io/reactivesocket/perfutil/PerfTestConnection.java
@@ -24,12 +24,12 @@ import org.reactivestreams.Subscription;
 import io.reactivesocket.Completable;
 import io.reactivesocket.DuplexConnection;
 import io.reactivesocket.Frame;
+import io.reactivesocket.observable.Observable;
 
 public class PerfTestConnection implements DuplexConnection {
 
-	public final PerfUnicastSubjectNoBackpressure toInput = PerfUnicastSubjectNoBackpressure.create();
-	private PerfUnicastSubjectNoBackpressure writeSubject = PerfUnicastSubjectNoBackpressure.create();
-	public final Publisher<Frame> writes = writeSubject;
+	public final PerfUnicastSubjectNoBackpressure<Frame> toInput = PerfUnicastSubjectNoBackpressure.create();
+	private PerfUnicastSubjectNoBackpressure<Frame> writeSubject = PerfUnicastSubjectNoBackpressure.create();
 
 	@Override
 	public void addOutput(Publisher<Frame> o, Completable callback) {
@@ -59,13 +59,13 @@ public class PerfTestConnection implements DuplexConnection {
 	}
 
 	@Override
-	public Publisher<Frame> getInput() {
+	public Observable<Frame> getInput() {
 		return toInput;
 	}
 
 	public void connectToServerConnection(PerfTestConnection serverConnection) {
-		writes.subscribe(serverConnection.toInput);
-		serverConnection.writes.subscribe(toInput);
+		writeSubject.subscribe(serverConnection.toInput);
+		serverConnection.writeSubject.subscribe(toInput);
 
 	}
 


### PR DESCRIPTION
I think it might be wrong to represent `getInput` as a `Publisher` since it can't respond to backpressure. 

Since we don't have concrete types (RxJava v1/v2) or anything else to represent this, I am (hopefully temporarily) creating `Observable`/`Observer`/`Disposable` interfaces to represent the `getInput`.