### PR TITLE
new TestConnection

### DIFF
--- a/src/test/java/io/reactivesocket/RequesterResponderInteractionTest.java
+++ b/src/test/java/io/reactivesocket/RequesterResponderInteractionTest.java
@@ -46,22 +46,9 @@ public class RequesterResponderInteractionTest
     public void setup() throws InterruptedException {
         System.out.println("-----------------------------------------------------------------------");
         TestConnection serverConnection = new TestConnection();
-        serverConnection.writes.forEach(n -> System.out.println("Writes from server->client: " + n));
-        serverConnection.toInput.forEach(n -> System.out.println("Input from client->server: " + n));
         TestConnection clientConnection = new TestConnection();
-        clientConnection.writes.forEach(n -> System.out.println("Writes from client->server: " + n));
-        clientConnection.toInput.forEach(n -> System.out.println("Input from server->client: " + n));
-
-        // connect the connections (with a Scheduler to simulate async IO)
-        clientConnection.writes
-                .subscribeOn(Schedulers.computation())
-                .observeOn(Schedulers.computation())
-                .subscribe(serverConnection.toInput);
-        serverConnection.writes.observeOn(Schedulers.computation())
-                .subscribeOn(Schedulers.computation())
-                .observeOn(Schedulers.computation())
-                .subscribe(clientConnection.toInput);
-
+        clientConnection.connectToServerConnection(serverConnection);
+        
         LatchedCompletable lc = new LatchedCompletable(2);
         
         responder = Responder.create(serverConnection, setup -> new RequestHandler.Builder()

--- a/src/test/java/io/reactivesocket/internal/RequesterTest.java
+++ b/src/test/java/io/reactivesocket/internal/RequesterTest.java
@@ -69,7 +69,7 @@ public class RequesterTest
         assertEquals(FrameType.REQUEST_RESPONSE, two.getType());
         
         // now emit a response to ensure the Publisher receives and completes
-        conn.toInput.onNext(utf8EncodedResponseFrame(2, FrameType.NEXT_COMPLETE, "world"));
+        conn.toInput.send(utf8EncodedResponseFrame(2, FrameType.NEXT_COMPLETE, "world"));
 
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertValue(utf8EncodedPayload("world", null));
@@ -100,7 +100,7 @@ public class RequesterTest
         assertEquals("hello", byteToString(two.getData()));
         assertEquals(FrameType.REQUEST_RESPONSE, two.getType());
 
-        conn.toInput.onNext(Frame.Error.from(2, new RuntimeException("Failed")));
+        conn.toInput.send(Frame.Error.from(2, new RuntimeException("Failed")));
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertError(Exception.class);
         assertEquals("Failed", ts.errors().get(0).getMessage());
@@ -167,9 +167,9 @@ public class RequesterTest
         // TODO assert initial requestN
         
         // emit data
-        conn.toInput.onNext(utf8EncodedResponseFrame(2, FrameType.NEXT, "hello"));
-        conn.toInput.onNext(utf8EncodedResponseFrame(2, FrameType.NEXT, "world"));
-        conn.toInput.onNext(utf8EncodedResponseFrame(2, FrameType.COMPLETE, ""));
+        conn.toInput.send(utf8EncodedResponseFrame(2, FrameType.NEXT, "hello"));
+        conn.toInput.send(utf8EncodedResponseFrame(2, FrameType.NEXT, "world"));
+        conn.toInput.send(utf8EncodedResponseFrame(2, FrameType.COMPLETE, ""));
 
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertComplete();
@@ -203,8 +203,8 @@ public class RequesterTest
         // TODO assert initial requestN
 
         // emit data
-        conn.toInput.onNext(utf8EncodedResponseFrame(2, FrameType.NEXT, "hello"));
-        conn.toInput.onNext(utf8EncodedResponseFrame(2, FrameType.NEXT, "world"));
+        conn.toInput.send(utf8EncodedResponseFrame(2, FrameType.NEXT, "hello"));
+        conn.toInput.send(utf8EncodedResponseFrame(2, FrameType.NEXT, "world"));
 
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertComplete();
@@ -246,8 +246,8 @@ public class RequesterTest
         // TODO assert initial requestN
 
         // emit data
-        conn.toInput.onNext(utf8EncodedResponseFrame(2, FrameType.NEXT, "hello"));
-        conn.toInput.onNext(utf8EncodedErrorFrame(2, "Failure"));
+        conn.toInput.send(utf8EncodedResponseFrame(2, FrameType.NEXT, "hello"));
+        conn.toInput.send(utf8EncodedErrorFrame(2, "Failure"));
 
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertError(Exception.class);
@@ -269,7 +269,7 @@ public class RequesterTest
     private ReplaySubject<Frame> captureRequests(TestConnection conn) {
         ReplaySubject<Frame> rs = ReplaySubject.create();
         rs.forEach(i -> System.out.println("capturedRequest => " + i));
-        conn.writes.subscribe(rs);
+        conn.write.add(rs::onNext);
         return rs;
     }
 }


### PR DESCRIPTION
Replace use of Subjects with simple event propagation. The RxJava v2 subjects are causing me grief, so I'm eliminating their use for now.

Also, this removes concurrency for now.