### PR TITLE
Compose Request(n) – Transport/Application

### DIFF
--- a/src/test/java/io/reactivesocket/SerializedEventBus.java
+++ b/src/test/java/io/reactivesocket/SerializedEventBus.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivesocket;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+import io.reactivesocket.observable.Observer;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.Subject;
+
+/**
+ * Multicast eventbus that serializes incoming events.
+ */
+public class SerializedEventBus {
+
+	private final CopyOnWriteArrayList<Observer<Frame>> os = new CopyOnWriteArrayList<>();
+	private Subject<Frame, Frame> s;
+	
+	public SerializedEventBus() {
+		s = PublishSubject.<Frame>create().toSerialized();
+		s.subscribe(f-> {
+			for (Observer<Frame> o : os) {
+				o.onNext(f);
+			}	
+		});
+	}
+	
+	public void send(Frame f) {
+		s.onNext(f);
+	}
+
+	public void add(Observer<Frame> o) {
+		os.add(o);
+	}
+
+	public void add(Consumer<Frame> f) {
+		add(new Observer<Frame>() {
+
+			@Override
+			public void onNext(Frame t) {
+				f.accept(t);
+			}
+
+			@Override
+			public void onError(Throwable e) {
+
+			}
+
+			@Override
+			public void onComplete() {
+
+			}
+
+			@Override
+			public void onSubscribe(io.reactivesocket.observable.Disposable d) {
+				// TODO Auto-generated method stub
+
+			}
+
+		});
+	}
+
+	public void remove(Observer<Frame> o) {
+		os.remove(o);
+	}
+}

--- a/src/test/java/io/reactivesocket/TestConnectionWithControlledRequestN.java
+++ b/src/test/java/io/reactivesocket/TestConnectionWithControlledRequestN.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivesocket;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Connection that by defaults only calls request(1) on a Publisher to addOutput. Any further must be done via requestMore(n)
+ * <p>
+ * NOTE: This should ONLY be used for 1 test at a time as it maintains state. Call close() when done.
+ */
+public class TestConnectionWithControlledRequestN extends TestConnection {
+
+	public List<Subscription> subscriptions = Collections.synchronizedList(new ArrayList<Subscription>());
+	public AtomicLong emitted = new AtomicLong();
+	public AtomicLong requested = new AtomicLong();
+
+	@Override
+	public void addOutput(Publisher<Frame> o, Completable callback) {
+		System.out.println("TestConnectionWithControlledRequestN => addOutput");
+		o.subscribe(new Subscriber<Frame>() {
+
+			volatile Subscription _s = null;
+			public AtomicLong sEmitted = new AtomicLong();
+
+			@Override
+			public void onSubscribe(Subscription s) {
+				_s = new Subscription() {
+
+					@Override
+					public void request(long n) {
+						requested.addAndGet(n);
+						s.request(n);
+					}
+
+					@Override
+					public void cancel() {
+						subscriptions.remove(_s);
+						s.cancel();
+					}
+
+				};
+				subscriptions.add(_s);
+				_s.request(1);
+			}
+
+			@Override
+			public void onNext(Frame t) {
+				emitted.incrementAndGet();
+				sEmitted.incrementAndGet();
+				write.send(t);
+			}
+
+			@Override
+			public void onError(Throwable t) {
+				subscriptions.remove(_s);
+				callback.error(t);
+			}
+
+			@Override
+			public void onComplete() {
+				System.out.println("TestConnectionWithControlledRequestN => complete, emitted: " + sEmitted.get());
+				subscriptions.remove(_s);
+				callback.success();
+			}
+
+		});
+
+	}
+
+	public boolean awaitSubscription(int timeInMillis) {
+		long start = System.currentTimeMillis();
+		while (subscriptions.size() == 0) {
+			Thread.yield();
+			if(System.currentTimeMillis() - start > timeInMillis) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Request more against the first subscription. This will ONLY request against the oldest Subscription, one at a time.
+	 * <p>
+	 * When one completes, it does NOT propagate request(n) to the next. Thus, this assumes unit tests where you know what you are doing with request(n).
+	 * 
+	 * @param n
+	 */
+	public void requestMore(int n) {
+		if (subscriptions.size() == 0) {
+			throw new IllegalStateException("no subscriptions to request from");
+		}
+		subscriptions.get(0).request(n);
+	}
+
+}

--- a/src/test/java/io/reactivesocket/TestTransportRequestN.java
+++ b/src/test/java/io/reactivesocket/TestTransportRequestN.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivesocket;
+
+import static io.reactivesocket.TestUtil.*;
+import static io.reactivex.Observable.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.subscribers.TestSubscriber;
+
+/**
+ * Ensure that request(n) from DuplexConnection "transport" layer is respected.
+ *
+ */
+public class TestTransportRequestN {
+
+	@Test(timeout = 3000)
+	public void testRequestNFromTransport() throws InterruptedException {
+		serverConnection = new TestConnectionWithControlledRequestN();
+		setup(serverConnection);
+
+		TestSubscriber<Payload> ts = new TestSubscriber<>();
+		fromPublisher(socketClient.requestStream(utf8EncodedPayload("", null)))
+				.take(150)
+				.subscribe(ts);
+
+		// wait for server to add output
+		if (!serverConnection.awaitSubscription(1000)) {
+			fail("Did not receive subscription");
+		}
+		// now request some data, but less than it is expected to output
+		serverConnection.requestMore(10);
+
+		// since we are async, give time for emission to occur
+		Thread.sleep(500);
+
+		// we should not have received more than 11 (10 + default 1 that is requested)
+
+		if (ts.valueCount() > 11) {
+			fail("Received more (" + ts.valueCount() + ") than transport requested (11)");
+		}
+
+		ts.cancel();
+
+		// since we are async, give time for emission to occur
+		Thread.sleep(500);
+
+		if (serverConnection.emitted.get() > serverConnection.requested.get()) {
+			fail("Emitted more (" + serverConnection.emitted.get() + ") than transport requested (" + serverConnection.requested.get() + ")");
+		}
+	}
+
+	private TestConnectionWithControlledRequestN serverConnection;
+	private ReactiveSocket socketServer;
+	private ReactiveSocket socketClient;
+	private AtomicBoolean helloSubscriptionRunning = new AtomicBoolean(false);
+	private AtomicReference<Throwable> lastServerError = new AtomicReference<Throwable>();
+	private CountDownLatch lastServerErrorCountDown;
+
+	public void setup(TestConnectionWithControlledRequestN serverConnection) throws InterruptedException {
+		TestConnection clientConnection = new TestConnection();
+		clientConnection.connectToServerConnection(serverConnection, false);
+		lastServerErrorCountDown = new CountDownLatch(1);
+
+		socketServer = ReactiveSocket.fromServerConnection(serverConnection, setup -> new RequestHandler() {
+
+			@Override
+			public Publisher<Payload> handleRequestResponse(Payload payload) {
+				return just(utf8EncodedPayload("request_response", null));
+			}
+
+			@Override
+			public Publisher<Payload> handleRequestStream(Payload payload) {
+				return range(0, 10000).map(i -> "stream_response_" + i).map(n -> utf8EncodedPayload(n, null));
+			}
+
+			@Override
+			public Publisher<Payload> handleSubscription(Payload payload) {
+				return interval(1, TimeUnit.MILLISECONDS)
+						.onBackpressureDrop()
+						.doOnSubscribe(s -> helloSubscriptionRunning.set(true))
+						.doOnCancel(() -> helloSubscriptionRunning.set(false))
+						.map(i -> "subscription " + i)
+						.map(n -> utf8EncodedPayload(n, null));
+			}
+
+			@Override
+			public Publisher<Void> handleFireAndForget(Payload payload) {
+				return error(new RuntimeException("Not Found"));
+			}
+
+			/**
+			 * Use Payload.metadata for routing
+			 */
+			@Override
+			public Publisher<Payload> handleChannel(Payload initialPayload, Publisher<Payload> payloads) {
+				return range(0, 10000).map(i -> "channel_response_" + i).map(n -> utf8EncodedPayload(n, null));
+			}
+
+			@Override
+			public Publisher<Void> handleMetadataPush(Payload payload) {
+				return error(new RuntimeException("Not Found"));
+			}
+
+		}, new FairLeaseGovernor(100, 10L, TimeUnit.SECONDS), t -> {
+			t.printStackTrace();
+			lastServerError.set(t);
+			lastServerErrorCountDown.countDown();
+		});
+
+		socketClient = ReactiveSocket.fromClientConnection(
+				clientConnection,
+				ConnectionSetupPayload.create("UTF-8", "UTF-8", ConnectionSetupPayload.NO_FLAGS),
+				err -> err.printStackTrace());
+
+		// start both the server and client and monitor for errors
+		socketServer.startAndWait();
+		socketClient.startAndWait();
+	}
+
+	@After
+	public void shutdown() {
+		socketServer.shutdown();
+		socketClient.shutdown();
+		try {
+			serverConnection.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
Stop ignoring the `request(n)` of the transport layer.