### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/io/reactivesocket/Frame.java
+++ b/src/main/java/io/reactivesocket/Frame.java
@@ -257,6 +257,9 @@ public class Frame implements Payload
     // SETUP specific getters
     public static class Setup
     {
+
+        private Setup() {}
+
         public static Frame from(
             int flags,
             int keepaliveInterval,
@@ -317,6 +320,9 @@ public class Frame implements Payload
 
     public static class Error
     {
+
+        private Error() {}
+
         public static Frame from(
             int streamId,
             final Throwable throwable,
@@ -360,6 +366,8 @@ public class Frame implements Payload
 
     public static class Lease
     {
+        private Lease() {}
+
         public static Frame from(int ttl, int numberOfRequests, ByteBuffer metadata)
         {
             final Frame frame = POOL.acquireFrame(LeaseFrameFlyweight.computeFrameLength(metadata.remaining()));
@@ -383,6 +391,8 @@ public class Frame implements Payload
 
     public static class RequestN
     {
+        private RequestN() {}
+
         public static Frame from(int streamId, int requestN)
         {
             final Frame frame = POOL.acquireFrame(RequestNFrameFlyweight.computeFrameLength());
@@ -400,6 +410,8 @@ public class Frame implements Payload
 
     public static class Request
     {
+        private Request() {}
+
         public static Frame from(int streamId, FrameType type, Payload payload, int initialRequestN)
         {
             final ByteBuffer d = payload.getData() != null ? payload.getData() : NULL_BYTEBUFFER;
@@ -473,6 +485,9 @@ public class Frame implements Payload
 
     public static class Response
     {
+
+        private Response() {}
+
         public static Frame from(int streamId, FrameType type, Payload payload)
         {
             final ByteBuffer data = payload.getData() != null ? payload.getData() : NULL_BYTEBUFFER;
@@ -507,6 +522,9 @@ public class Frame implements Payload
 
     public static class Cancel
     {
+
+        private Cancel() {}
+
         public static Frame from(int streamId)
         {
             final Frame frame =
@@ -520,6 +538,9 @@ public class Frame implements Payload
 
     public static class Keepalive
     {
+
+        private Keepalive() {}
+
         public static Frame from(ByteBuffer data, boolean respond)
         {
             final Frame frame =

--- a/src/main/java/io/reactivesocket/FrameType.java
+++ b/src/main/java/io/reactivesocket/FrameType.java
@@ -47,6 +47,8 @@ public enum FrameType
 
     private static class Flags
     {
+        private Flags() {}
+
         private static final int CAN_HAVE_DATA = 0b0001;
         private static final int CAN_HAVE_METADATA = 0b0010;
         private static final int CAN_HAVE_METADATA_AND_DATA = 0b0011;

--- a/src/main/java/io/reactivesocket/exceptions/Exceptions.java
+++ b/src/main/java/io/reactivesocket/exceptions/Exceptions.java
@@ -23,6 +23,9 @@ import static io.reactivesocket.internal.frame.ErrorFrameFlyweight.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Exceptions {
+
+    private Exceptions() {}
+
     public static Throwable from(Frame frame) {
         final int errorCode = Frame.Error.errorCode(frame);
         String message = "<empty message>";

--- a/src/main/java/io/reactivesocket/internal/PublisherUtils.java
+++ b/src/main/java/io/reactivesocket/internal/PublisherUtils.java
@@ -34,6 +34,8 @@ import io.reactivesocket.internal.rx.SubscriptionHelper;
 
 public class PublisherUtils {
 
+	private PublisherUtils() {}
+
 	// TODO: be better about using scheduler for this
 	public static final ScheduledExecutorService SCHEDULER_THREAD = Executors.newScheduledThreadPool(1,
 		(r) -> {

--- a/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
+++ b/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
@@ -19,6 +19,9 @@ import java.nio.ByteBuffer;
 
 public class ByteBufferUtil
 {
+
+    private ByteBufferUtil() {}
+
     /**
      * Slice a portion of the {@link ByteBuffer} while preserving the buffers position and limit.
      *

--- a/src/main/java/io/reactivesocket/internal/frame/ErrorFrameFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/frame/ErrorFrameFlyweight.java
@@ -32,6 +32,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 public class ErrorFrameFlyweight {
+
+    private ErrorFrameFlyweight() {}
+
     // defined error codes
     public static final int INVALID_SETUP = 0x0001;
     public static final int UNSUPPORTED_SETUP = 0x0002;

--- a/src/main/java/io/reactivesocket/internal/frame/FrameHeaderFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/frame/FrameHeaderFlyweight.java
@@ -37,6 +37,9 @@ import static io.reactivesocket.internal.frame.ByteBufferUtil.preservingSlice;
  */
 public class FrameHeaderFlyweight
 {
+
+    private FrameHeaderFlyweight() {}
+
     public static final ByteBuffer NULL_BYTEBUFFER = ByteBuffer.allocate(0);
 
     public static final int FRAME_HEADER_LENGTH;

--- a/src/main/java/io/reactivesocket/internal/frame/KeepaliveFrameFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/frame/KeepaliveFrameFlyweight.java
@@ -23,6 +23,8 @@ import java.nio.ByteBuffer;
 
 public class KeepaliveFrameFlyweight
 {
+    private KeepaliveFrameFlyweight() {}
+
     private static final int PAYLOAD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;
 
     public static int computeFrameLength(final int dataLength)

--- a/src/main/java/io/reactivesocket/internal/frame/LeaseFrameFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/frame/LeaseFrameFlyweight.java
@@ -25,6 +25,8 @@ import java.nio.ByteOrder;
 
 public class LeaseFrameFlyweight
 {
+    private LeaseFrameFlyweight() {}
+
     // relative to start of passed offset
     private static final int TTL_FIELD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;
     private static final int NUM_REQUESTS_FIELD_OFFSET = TTL_FIELD_OFFSET + BitUtil.SIZE_OF_INT;

--- a/src/main/java/io/reactivesocket/internal/frame/RequestFrameFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/frame/RequestFrameFlyweight.java
@@ -25,6 +25,9 @@ import java.nio.ByteOrder;
 
 public class RequestFrameFlyweight
 {
+
+    private RequestFrameFlyweight() {}
+
     public static final int FLAGS_REQUEST_CHANNEL_C = 0b0001_0000_0000_0000;
     public static final int FLAGS_REQUEST_CHANNEL_N = 0b0000_1000_0000_0000;
 

--- a/src/main/java/io/reactivesocket/internal/frame/RequestNFrameFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/frame/RequestNFrameFlyweight.java
@@ -24,6 +24,8 @@ import java.nio.ByteOrder;
 
 public class RequestNFrameFlyweight
 {
+    private RequestNFrameFlyweight() {}
+
     // relative to start of passed offset
     private static final int REQUEST_N_FIELD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;
 

--- a/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
@@ -26,6 +26,8 @@ import java.nio.charset.Charset;
 
 public class SetupFrameFlyweight
 {
+    private SetupFrameFlyweight() {}
+
     public static final int FLAGS_WILL_HONOR_LEASE = 0b0010_0000;
     public static final int FLAGS_STRICT_INTERPRETATION = 0b0001_0000;
 

--- a/src/test/java/io/reactivesocket/TestUtil.java
+++ b/src/test/java/io/reactivesocket/TestUtil.java
@@ -22,6 +22,8 @@ import java.nio.charset.Charset;
 
 public class TestUtil
 {
+    private TestUtil() {}
+
     public static Frame utf8EncodedRequestFrame(final int streamId, final FrameType type, final String data, final int initialRequestN)
     {
         return Frame.Request.from(streamId, type, new Payload()


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed