### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/io/reactivesocket/ConnectionSetupPayload.java
+++ b/src/main/java/io/reactivesocket/ConnectionSetupPayload.java
@@ -154,11 +154,11 @@ public abstract class ConnectionSetupPayload implements Payload
 
 	public boolean willClientHonorLease()
 	{
-		return (HONOR_LEASE == (getFlags() & HONOR_LEASE));
+		return HONOR_LEASE == (getFlags() & HONOR_LEASE);
 	}
 
 	public boolean doesClientRequestStrictInterpretation()
 	{
-		return (STRICT_INTERPRETATION == (getFlags() & STRICT_INTERPRETATION));
+		return STRICT_INTERPRETATION == (getFlags() & STRICT_INTERPRETATION);
 	}
 }

--- a/src/main/java/io/reactivesocket/Frame.java
+++ b/src/main/java/io/reactivesocket/Frame.java
@@ -337,7 +337,7 @@ public class Frame implements Payload
             final Throwable throwable,
             ByteBuffer metadata
         ) {
-            String data = (throwable.getMessage() == null ? "" : throwable.getMessage());
+            String data = throwable.getMessage() == null ? "" : throwable.getMessage();
             byte[] bytes = data.getBytes(Charset.forName("UTF-8"));
             final ByteBuffer dataBuffer = ByteBuffer.wrap(bytes);
 
@@ -525,7 +525,7 @@ public class Frame implements Payload
             final Frame frame =
                 POOL.acquireFrame(FrameHeaderFlyweight.computeFrameHeaderLength(FrameType.KEEPALIVE, 0, data.remaining()));
 
-            final int flags = (respond ? FrameHeaderFlyweight.FLAGS_KEEPALIVE_R : 0);
+            final int flags = respond ? FrameHeaderFlyweight.FLAGS_KEEPALIVE_R : 0;
 
             frame.length = FrameHeaderFlyweight.encode(
                 frame.directBuffer, frame.offset, 0, flags, FrameType.KEEPALIVE, Frame.NULL_BYTEBUFFER, data);

--- a/src/main/java/io/reactivesocket/FrameType.java
+++ b/src/main/java/io/reactivesocket/FrameType.java
@@ -92,22 +92,22 @@ public enum FrameType
 
     public boolean isRequestType()
     {
-        return (Flags.IS_REQUEST_TYPE == (flags & Flags.IS_REQUEST_TYPE));
+        return Flags.IS_REQUEST_TYPE == (flags & Flags.IS_REQUEST_TYPE);
     }
 
     public boolean hasInitialRequestN()
     {
-        return (Flags.HAS_INITIAL_REQUEST_N == (flags & Flags.HAS_INITIAL_REQUEST_N));
+        return Flags.HAS_INITIAL_REQUEST_N == (flags & Flags.HAS_INITIAL_REQUEST_N);
     }
 
     public boolean canHaveData()
     {
-        return (Flags.CAN_HAVE_DATA == (flags & Flags.CAN_HAVE_DATA));
+        return Flags.CAN_HAVE_DATA == (flags & Flags.CAN_HAVE_DATA);
     }
 
     public boolean canHaveMetadata()
     {
-        return (Flags.CAN_HAVE_METADATA == (flags & Flags.CAN_HAVE_METADATA));
+        return Flags.CAN_HAVE_METADATA == (flags & Flags.CAN_HAVE_METADATA);
     }
 
     // TODO: offset of metadata and data (simplify parsing) naming: endOfFrameHeaderOffset()

--- a/src/main/java/io/reactivesocket/RequestHandler.java
+++ b/src/main/java/io/reactivesocket/RequestHandler.java
@@ -23,22 +23,22 @@ import java.util.function.Function;
 public abstract class RequestHandler {
 
 	public static final Function<Payload, Publisher<Payload>> NO_REQUEST_RESPONSE_HANDLER =
-		(payload -> PublisherUtils.errorPayload(new RuntimeException("No 'requestResponse' handler")));
+		payload -> PublisherUtils.errorPayload(new RuntimeException("No 'requestResponse' handler"));
 
 	public static final Function<Payload, Publisher<Payload>> NO_REQUEST_STREAM_HANDLER =
-		(payload -> PublisherUtils.errorPayload(new RuntimeException("No 'requestStream' handler")));
+		payload -> PublisherUtils.errorPayload(new RuntimeException("No 'requestStream' handler"));
 
 	public static final Function<Payload, Publisher<Payload>> NO_REQUEST_SUBSCRIPTION_HANDLER =
-		(payload -> PublisherUtils.errorPayload(new RuntimeException("No 'requestSubscription' handler")));
+		payload -> PublisherUtils.errorPayload(new RuntimeException("No 'requestSubscription' handler"));
 
 	public static final Function<Payload, Publisher<Void>> NO_FIRE_AND_FORGET_HANDLER =
-		(payload -> PublisherUtils.errorVoid(new RuntimeException("No 'fireAndForget' handler")));
+		payload -> PublisherUtils.errorVoid(new RuntimeException("No 'fireAndForget' handler"));
 
 	public static final Function<Publisher<Payload>, Publisher<Payload>> NO_REQUEST_CHANNEL_HANDLER =
-		(payloads) -> PublisherUtils.errorPayload(new RuntimeException("No 'requestChannel' handler"));
+		payloads -> PublisherUtils.errorPayload(new RuntimeException("No 'requestChannel' handler"));
 
 	public static final Function<Payload, Publisher<Void>> NO_METADATA_PUSH_HANDLER =
-		(payload -> PublisherUtils.errorVoid(new RuntimeException("No 'metadataPush' handler")));
+		payload -> PublisherUtils.errorVoid(new RuntimeException("No 'metadataPush' handler"));
 
 	public abstract Publisher<Payload> handleRequestResponse(final Payload payload);
 

--- a/src/main/java/io/reactivesocket/internal/PublisherUtils.java
+++ b/src/main/java/io/reactivesocket/internal/PublisherUtils.java
@@ -209,7 +209,7 @@ public class PublisherUtils {
 	}
 	
 	public static final Publisher<Frame> fromIterable(Iterable<Frame> is) {
-		return new PublisherIterableSource<Frame>(is);
+		return new PublisherIterableSource<>(is);
 	}
 	
 	public static final class PublisherIterableSource<T> extends AtomicBoolean implements Publisher<T> {

--- a/src/main/java/io/reactivesocket/internal/UnicastSubject.java
+++ b/src/main/java/io/reactivesocket/internal/UnicastSubject.java
@@ -37,7 +37,7 @@ public final class UnicastSubject<T> implements Subscriber<T>, Publisher<T> {
 	private boolean subscribedTo = false;
 
 	public static <T> UnicastSubject<T> create() {
-		return new UnicastSubject<T>(null, r -> {});
+		return new UnicastSubject<>(null, r -> {});
 	}
 
 	/**
@@ -46,7 +46,7 @@ public final class UnicastSubject<T> implements Subscriber<T>, Publisher<T> {
 	 * @return
 	 */
 	public static <T> UnicastSubject<T> create(BiConsumer<UnicastSubject<T>, Long> onConnect, Consumer<Long> onRequest) {
-		return new UnicastSubject<T>(onConnect, onRequest);
+		return new UnicastSubject<>(onConnect, onRequest);
 	}
 	
 	/**
@@ -54,7 +54,7 @@ public final class UnicastSubject<T> implements Subscriber<T>, Publisher<T> {
 	 * @return
 	 */
 	public static <T> UnicastSubject<T> create(BiConsumer<UnicastSubject<T>, Long> onConnect) {
-		return new UnicastSubject<T>(onConnect,  r -> {});
+		return new UnicastSubject<>(onConnect,  r -> {});
 	}
 
 	private UnicastSubject(BiConsumer<UnicastSubject<T>, Long> onConnect, Consumer<Long> onRequest) {

--- a/src/main/java/io/reactivesocket/internal/frame/FrameHeaderFlyweight.java
+++ b/src/main/java/io/reactivesocket/internal/frame/FrameHeaderFlyweight.java
@@ -266,7 +266,7 @@ public class FrameHeaderFlyweight
 
         if (FLAGS_M == (FLAGS_M & directBuffer.getShort(offset + FLAGS_FIELD_OFFSET, ByteOrder.BIG_ENDIAN)))
         {
-            metadataLength = (directBuffer.getInt(metadataOffset(directBuffer, offset), ByteOrder.BIG_ENDIAN) & 0xFFFFFF);
+            metadataLength = directBuffer.getInt(metadataOffset(directBuffer, offset), ByteOrder.BIG_ENDIAN) & 0xFFFFFF;
         }
 
         return metadataLength;

--- a/src/main/java/io/reactivesocket/internal/frame/PayloadFragmenter.java
+++ b/src/main/java/io/reactivesocket/internal/frame/PayloadFragmenter.java
@@ -74,7 +74,7 @@ public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame>
         final ByteBuffer metadata = payload.getMetadata();
         final ByteBuffer data = payload.getData();
 
-        return (metadata.remaining() > metadataMtu || data.remaining() > dataMtu);
+        return metadata.remaining() > metadataMtu || data.remaining() > dataMtu;
     }
 
     public Iterator<Frame> iterator()
@@ -84,7 +84,7 @@ public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame>
 
     public boolean hasNext()
     {
-        return (dataOffset < data.capacity() || metadataOffset < metadata.remaining());
+        return dataOffset < data.capacity() || metadataOffset < metadata.remaining();
     }
 
     public Frame next()
@@ -103,7 +103,7 @@ public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame>
         metadataOffset += metadataLength;
         dataOffset += dataLength;
 
-        final boolean isMoreFollowing = (metadataOffset < metadata.remaining() || dataOffset < data.remaining());
+        final boolean isMoreFollowing = metadataOffset < metadata.remaining() || dataOffset < data.remaining();
         int flags = 0;
 
         if (Type.RESPONSE == type)

--- a/src/perf/java/io/reactivesocket/perfutil/PerfUnicastSubjectNoBackpressure.java
+++ b/src/perf/java/io/reactivesocket/perfutil/PerfUnicastSubjectNoBackpressure.java
@@ -31,7 +31,7 @@ public final class PerfUnicastSubjectNoBackpressure<T> implements Observable<T>,
 	private boolean subscribedTo = false;
 
 	public static <T> PerfUnicastSubjectNoBackpressure<T> create() {
-		return new PerfUnicastSubjectNoBackpressure<T>(null);
+		return new PerfUnicastSubjectNoBackpressure<>(null);
 	}
 
 	/**
@@ -39,7 +39,7 @@ public final class PerfUnicastSubjectNoBackpressure<T> implements Observable<T>,
 	 * @return
 	 */
 	public static <T> PerfUnicastSubjectNoBackpressure<T> create(Consumer<PerfUnicastSubjectNoBackpressure<T>> onConnect) {
-		return new PerfUnicastSubjectNoBackpressure<T>(onConnect);
+		return new PerfUnicastSubjectNoBackpressure<>(onConnect);
 	}
 
 	private PerfUnicastSubjectNoBackpressure(Consumer<PerfUnicastSubjectNoBackpressure<T>> onConnect) {

--- a/src/test/java/io/reactivesocket/ReactiveSocketTest.java
+++ b/src/test/java/io/reactivesocket/ReactiveSocketTest.java
@@ -48,9 +48,9 @@ public class ReactiveSocketTest {
 	private ReactiveSocket socketServer;
 	private ReactiveSocket socketClient;
 	private AtomicBoolean helloSubscriptionRunning = new AtomicBoolean(false);
-	private AtomicReference<String> lastFireAndForget = new AtomicReference<String>();
-	private AtomicReference<String> lastMetadataPush = new AtomicReference<String>();
-	private AtomicReference<Throwable> lastServerError = new AtomicReference<Throwable>();
+	private AtomicReference<String> lastFireAndForget = new AtomicReference<>();
+	private AtomicReference<String> lastMetadataPush = new AtomicReference<>();
+	private AtomicReference<Throwable> lastServerError = new AtomicReference<>();
 	private CountDownLatch lastServerErrorCountDown;
 	private CountDownLatch fireAndForgetOrMetadataPush;
 

--- a/src/test/java/io/reactivesocket/TestTransportRequestN.java
+++ b/src/test/java/io/reactivesocket/TestTransportRequestN.java
@@ -165,7 +165,7 @@ public class TestTransportRequestN {
 	private ReactiveSocket socketServer;
 	private ReactiveSocket socketClient;
 	private AtomicBoolean helloSubscriptionRunning = new AtomicBoolean(false);
-	private AtomicReference<Throwable> lastServerError = new AtomicReference<Throwable>();
+	private AtomicReference<Throwable> lastServerError = new AtomicReference<>();
 	private CountDownLatch lastServerErrorCountDown;
 
 	public void setup(TestConnectionWithControlledRequestN clientConnection, TestConnectionWithControlledRequestN serverConnection) throws InterruptedException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2293 - The diamond operator ("<>") should be used.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed