### PR TITLE
Introduce Connector and availability for Connection

### DIFF
--- a/src/main/java/io/reactivesocket/DefaultReactiveSocket.java
+++ b/src/main/java/io/reactivesocket/DefaultReactiveSocket.java
@@ -440,6 +440,10 @@ public class DefaultReactiveSocket implements ReactiveSocket {
             connection.addOutput(f, callback);
         }
 
+        @Override
+        public double availability() {
+            return connection.availability();
+        }
     };
 
     @Override

--- a/src/main/java/io/reactivesocket/DuplexConnection.java
+++ b/src/main/java/io/reactivesocket/DuplexConnection.java
@@ -38,4 +38,10 @@ public interface DuplexConnection extends Closeable {
             s.onComplete();
         }, callback);
 	}
+
+    /**
+     * @return the availability of the underlying connection, a number in [0.0, 1.0]
+     * (higher is better).
+     */
+    double availability();
 }

--- a/src/main/java/io/reactivesocket/ReactiveSocket.java
+++ b/src/main/java/io/reactivesocket/ReactiveSocket.java
@@ -26,9 +26,9 @@ import java.util.function.Consumer;
  * Interface for a connection that supports sending requests and receiving responses
  */
 public interface ReactiveSocket extends AutoCloseable {
-    Publisher<Payload> requestResponse(final Payload payload);
-
     Publisher<Void> fireAndForget(final Payload payload);
+
+    Publisher<Payload> requestResponse(final Payload payload);
 
     Publisher<Payload> requestStream(final Payload payload);
 

--- a/src/main/java/io/reactivesocket/ReactiveSocketConnector.java
+++ b/src/main/java/io/reactivesocket/ReactiveSocketConnector.java
@@ -1,0 +1,76 @@
+package io.reactivesocket;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface ReactiveSocketConnector<T> {
+    /**
+     * Asynchronously connect and construct a ReactiveSocket
+     * @return a Publisher that will return the ReactiveSocket
+     */
+    Publisher<ReactiveSocket> connect(T address);
+
+    /**
+     * Transform the ReactiveSocket returned by the connector via the provided function `func`
+     * @param func the transformative function
+     * @return a new ReactiveSocketConnector
+     */
+    default ReactiveSocketConnector<T> chain(Function<ReactiveSocket, ReactiveSocket> func) {
+        return new ReactiveSocketConnector<T>() {
+            @Override
+            public Publisher<ReactiveSocket> connect(T address) {
+                return subscriber ->
+                    ReactiveSocketConnector.this.connect(address).subscribe(new Subscriber<ReactiveSocket>() {
+                        @Override
+                        public void onSubscribe(Subscription s) {
+                            subscriber.onSubscribe(s);
+                        }
+
+                        @Override
+                        public void onNext(ReactiveSocket reactiveSocket) {
+                            ReactiveSocket socket = func.apply(reactiveSocket);
+                            subscriber.onNext(socket);
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            subscriber.onError(t);
+                        }
+
+                        @Override
+                        public void onComplete() {
+                            subscriber.onComplete();
+                        }
+                    });
+            }
+        };
+    }
+
+    /**
+     * Create a ReactiveSocketFactory from a ReactiveSocketConnector
+     * @param address the address to connect the connector to
+     * @return the factory
+     */
+    default ReactiveSocketFactory<T> toFactory(T address) {
+        return new ReactiveSocketFactory<T>() {
+            @Override
+            public Publisher<ReactiveSocket> apply() {
+                return ReactiveSocketConnector.this.connect(address);
+            }
+
+            @Override
+            public double availability() {
+                return 1.0;
+            }
+
+            @Override
+            public T remote() {
+                return address;
+            }
+        };
+    }
+}

--- a/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/src/main/java/io/reactivesocket/internal/Requester.java
@@ -286,14 +286,14 @@ public class Requester {
      */
     public double availability() {
         if (!honorLease) {
-            return 1.0;
+            return connection.availability();
         }
         final long now = System.currentTimeMillis();
         double available = 0.0;
         if (numberOfRemainingRequests > 0 && (now < ttlExpiration)) {
             available = 1.0;
         }
-        return available;
+        return available * connection.availability();
     }
 
     /*
@@ -873,6 +873,7 @@ public class Requester {
 
                         Publisher<Frame> keepaliveTicker =
                             PublisherUtils.keepaliveTicker(KEEPALIVE_INTERVAL_MS, TimeUnit.MILLISECONDS);
+
                         connection.addOutput(keepaliveTicker,
                             new Completable() {
                                 public void success() {}

--- a/src/main/java/io/reactivesocket/util/ReactiveSocketProxy.java
+++ b/src/main/java/io/reactivesocket/util/ReactiveSocketProxy.java
@@ -69,7 +69,6 @@ public class ReactiveSocketProxy implements ReactiveSocket {
                 child.requestStream(payload).subscribe(subscriber);
             };
         }
-
     }
 
     @Override
@@ -82,7 +81,6 @@ public class ReactiveSocketProxy implements ReactiveSocket {
                 child.requestSubscription(payload).subscribe(subscriber);
             };
         }
-
     }
 
     @Override
@@ -95,7 +93,6 @@ public class ReactiveSocketProxy implements ReactiveSocket {
                 child.requestChannel(payloads).subscribe(subscriber);
             };
         }
-
     }
 
     @Override

--- a/src/main/java/io/reactivesocket/util/ReactiveSocketProxy.java
+++ b/src/main/java/io/reactivesocket/util/ReactiveSocketProxy.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivesocket.util;
+
+import io.reactivesocket.Payload;
+import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.rx.Completable;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+
+/**
+ * Wrapper/Proxy for a ReactiveSocket.
+ * This is useful when we want to override a specific method.
+ */
+public class ReactiveSocketProxy implements ReactiveSocket {
+    protected final ReactiveSocket child;
+    private final Function<Subscriber<? super Payload>, Subscriber<? super Payload>> subscriberWrapper;
+
+    public ReactiveSocketProxy(ReactiveSocket child, Function<Subscriber<? super Payload>, Subscriber<? super Payload>> subscriberWrapper) {
+        this.child = child;
+        this.subscriberWrapper = subscriberWrapper;
+    }
+
+    public ReactiveSocketProxy(ReactiveSocket child) {
+        this(child, null);
+    }
+
+    @Override
+    public Publisher<Void> fireAndForget(Payload payload) {
+        return child.fireAndForget(payload);
+    }
+
+    @Override
+    public Publisher<Payload> requestResponse(Payload payload) {
+        if (subscriberWrapper == null) {
+            return child.requestResponse(payload);
+        } else {
+            return s -> {
+                Subscriber<? super Payload> subscriber = subscriberWrapper.apply(s);
+                child.requestResponse(payload).subscribe(subscriber);
+            };
+        }
+    }
+
+    @Override
+    public Publisher<Payload> requestStream(Payload payload) {
+        if (subscriberWrapper == null) {
+            return child.requestStream(payload);
+        } else {
+            return s -> {
+                Subscriber<? super Payload> subscriber = subscriberWrapper.apply(s);
+                child.requestStream(payload).subscribe(subscriber);
+            };
+        }
+
+    }
+
+    @Override
+    public Publisher<Payload> requestSubscription(Payload payload) {
+        if (subscriberWrapper == null) {
+            return child.requestSubscription(payload);
+        } else {
+            return s -> {
+                Subscriber<? super Payload> subscriber = subscriberWrapper.apply(s);
+                child.requestSubscription(payload).subscribe(subscriber);
+            };
+        }
+
+    }
+
+    @Override
+    public Publisher<Payload> requestChannel(Publisher<Payload> payloads) {
+        if (subscriberWrapper == null) {
+            return child.requestChannel(payloads);
+        } else {
+            return s -> {
+                Subscriber<? super Payload> subscriber = subscriberWrapper.apply(s);
+                child.requestChannel(payloads).subscribe(subscriber);
+            };
+        }
+
+    }
+
+    @Override
+    public Publisher<Void> metadataPush(Payload payload) {
+        return child.metadataPush(payload);
+    }
+
+    @Override
+    public double availability() {
+        return child.availability();
+    }
+
+    @Override
+    public void start(Completable c) {
+        child.start(c);
+    }
+
+    @Override
+    public void onRequestReady(Consumer<Throwable> c) {
+        child.onRequestReady(c);
+    }
+
+    @Override
+    public void onRequestReady(Completable c) {
+        child.onRequestReady(c);
+    }
+
+    @Override
+    public void onShutdown(Completable c) {
+        child.onShutdown(c);
+    }
+
+    @Override
+    public void sendLease(int ttl, int numberOfRequests) {
+        child.sendLease(ttl, numberOfRequests);
+    }
+
+    @Override
+    public void shutdown() {
+        child.shutdown();
+    }
+
+    @Override
+    public void close() throws Exception {
+        child.close();
+    }
+
+    @Override
+    public String toString() {
+        return "ReactiveSocketProxy(" + child.toString() + ")";
+    }
+}

--- a/src/perf/java/io/reactivesocket/perfutil/PerfTestConnection.java
+++ b/src/perf/java/io/reactivesocket/perfutil/PerfTestConnection.java
@@ -65,6 +65,11 @@ public class PerfTestConnection implements DuplexConnection {
 	}
 
 	@Override
+	public double availability() {
+		return 1.0;
+	}
+
+	@Override
 	public Observable<Frame> getInput() {
 		return toInput;
 	}
@@ -72,11 +77,9 @@ public class PerfTestConnection implements DuplexConnection {
 	public void connectToServerConnection(PerfTestConnection serverConnection) {
 		writeSubject.subscribe(serverConnection.toInput);
 		serverConnection.writeSubject.subscribe(toInput);
-
 	}
 
 	@Override
 	public void close() throws IOException {
-		
 	}
 }

--- a/src/test/java/io/reactivesocket/TestConnection.java
+++ b/src/test/java/io/reactivesocket/TestConnection.java
@@ -49,6 +49,11 @@ public class TestConnection implements DuplexConnection {
 	}
 
 	@Override
+	public double availability() {
+		return 1.0;
+	}
+
+	@Override
 	public io.reactivesocket.rx.Observable<Frame> getInput() {
 		return new io.reactivesocket.rx.Observable<Frame>() {
 


### PR DESCRIPTION
**Problem**
The DuplexConnection class doesn't expose any way to probe its state,
this is somewhat problematic and doesn't fit well in the current
model where the availability is the composable way of chaining state.

The ReactiveSocketFactory create a ReactiveSocket from an `address`
(currently SocketAddress). There are places in the code where the concept
of address is not needed and it leads to implicit dependency on it.

**Solution**
Add a `double availability()` method to the DuplexConnection interface,
most implementation of this method will be straightforward (just
returning 0.0 if the underlying resource is unavailable, 1.0 otherwise).

Split the concept of ReactiveSocketFactory in two, the Factory and the
Connector. The Connector is responsible for creating the ReactiveSocket
from the address, and the factory can create a ReactiveSocket without
any argument.

**Modification**
I added a `ReactiveSocketProxy` helper class, which ease the task of wrapping
a ReactiveSocket instance for extending its behavior.