### PR TITLE
Unknown Stream Id frame shutdown connection.

### DIFF
--- a/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/src/main/java/io/reactivesocket/internal/Requester.java
@@ -923,23 +923,8 @@ public class Requester {
                         streamSubject = streamInputMap.get(streamId);
                     }
                     if (streamSubject == null) {
-                        if (streamId <= streamCount) {
-                            // receiving a frame after a given stream has been cancelled/completed,
-                            // so ignore (cancellation is async so there is a race condition)
-                            return;
-                        } else {
-                            // message for stream that has never existed, we have a problem with
-                            // the overall connection and must tear down
-                            if (frame.getType() == FrameType.ERROR) {
-                                String errorMessage = getByteBufferAsString(frame.getData());
-                                onError(new RuntimeException(
-                                    "Received error for non-existent stream: "
-                                        + streamId + " Message: " + errorMessage));
-                            } else {
-                                onError(new RuntimeException(
-                                    "Received message for non-existent stream: " + streamId));
-                            }
-                        }
+                        errorStream.accept(new RuntimeException("Received message for completed/non-existent stream: "
+                                                                + streamId));
                     } else {
                         streamSubject.onNext(frame);
                     }

--- a/src/test/java/io/reactivesocket/TestConnection.java
+++ b/src/test/java/io/reactivesocket/TestConnection.java
@@ -32,6 +32,8 @@ public class TestConnection implements DuplexConnection {
 	public final SerializedEventBus toInput = new SerializedEventBus();
 	public final SerializedEventBus write = new SerializedEventBus();
 
+    private volatile boolean closed;
+
 	@Override
 	public void addOutput(Publisher<Frame> o, Completable callback) {
 		fromPublisher(o).flatMap(m -> {
@@ -102,8 +104,12 @@ public class TestConnection implements DuplexConnection {
 
 	@Override
 	public void close() throws IOException {
-		clientThread.dispose();
+        closed = true;
+        clientThread.dispose();
 		serverThread.dispose();
 	}
 
+    public boolean isClosed() {
+        return closed;
+    }
 }


### PR DESCRIPTION
If a frame with non-existent (terminated or unknown) stream Id arrives on a connection, the connection was shutdown.
This change sends the error to the error stream for the connection instead and hence ignores such a frame.