### PR TITLE
Refactor ReactiveSocketServerHandler to be not shareable.

### DIFF
--- a/reactivesocket-transport-tcp/src/examples/java/io/reactivesocket/transport/tcp/EchoServerHandler.java
+++ b/reactivesocket-transport-tcp/src/examples/java/io/reactivesocket/transport/tcp/EchoServerHandler.java
@@ -16,11 +16,10 @@ import java.util.List;
 public class EchoServerHandler extends ByteToMessageDecoder {
     private static SimpleChannelInboundHandler<FullHttpRequest> httpHandler = new HttpServerHandler();
 
-    private static ReactiveSocketServerHandler reactiveSocketHandler = ReactiveSocketServerHandler.create((setupPayload, rs) ->
-        new RequestHandler.Builder().withRequestResponse(payload -> s -> {
-            s.onNext(payload);
-            s.onComplete();
-        }).build());
+    private static RequestHandler requestHandler = new RequestHandler.Builder().withRequestResponse(payload -> s -> {
+        s.onNext(payload);
+        s.onComplete();
+    }).build();
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -61,6 +60,8 @@ public class EchoServerHandler extends ByteToMessageDecoder {
 
     private void switchToReactiveSocket(ChannelHandlerContext ctx) {
         ChannelPipeline p = ctx.pipeline();
+        ReactiveSocketServerHandler reactiveSocketHandler =
+            ReactiveSocketServerHandler.create((setupPayload, rs) -> requestHandler);
         p.addLast(reactiveSocketHandler);
         p.remove(this);
     }

--- a/reactivesocket-transport-websocket/src/test/java/io/reactivesocket/transport/websocket/Ping.java
+++ b/reactivesocket-transport-websocket/src/test/java/io/reactivesocket/transport/websocket/Ping.java
@@ -35,10 +35,16 @@ import java.util.concurrent.TimeUnit;
 
 public class Ping {
     public static void main(String... args) throws Exception {
-        Publisher<ClientWebSocketDuplexConnection> publisher = ClientWebSocketDuplexConnection.create(InetSocketAddress.createUnresolved("localhost", 8025), "/rs", new NioEventLoopGroup(1));
+        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(1);
 
-        ClientWebSocketDuplexConnection duplexConnection = RxReactiveStreams.toObservable(publisher).toBlocking().last();
-        ReactiveSocket reactiveSocket = DefaultReactiveSocket.fromClientConnection(duplexConnection, ConnectionSetupPayload.create("UTF-8", "UTF-8"), t -> t.printStackTrace());
+        Publisher<ClientWebSocketDuplexConnection> publisher =
+            ClientWebSocketDuplexConnection.create(InetSocketAddress.createUnresolved("localhost", 8025), "/rs", eventLoopGroup);
+
+        ClientWebSocketDuplexConnection duplexConnection =
+            RxReactiveStreams.toObservable(publisher).toBlocking().last();
+        ConnectionSetupPayload setupPayload = ConnectionSetupPayload.create("UTF-8", "UTF-8");
+        ReactiveSocket reactiveSocket =
+            DefaultReactiveSocket.fromClientConnection(duplexConnection, setupPayload, Throwable::printStackTrace);
 
         reactiveSocket.startAndWait();
 

--- a/reactivesocket-transport-websocket/src/test/java/io/reactivesocket/transport/websocket/Pong.java
+++ b/reactivesocket-transport-websocket/src/test/java/io/reactivesocket/transport/websocket/Pong.java
@@ -45,113 +45,68 @@ public class Pong {
         Random r = new Random();
         r.nextBytes(response);
 
-        ReactiveSocketServerHandler serverHandler =
-            ReactiveSocketServerHandler.create((setupPayload, rs) -> new RequestHandler() {
-                @Override
-                public Publisher<Payload> handleRequestResponse(Payload payload) {
-                    return new Publisher<Payload>() {
+        RequestHandler requestHandler = new RequestHandler() {
+            @Override
+            public Publisher<Payload> handleRequestResponse(Payload payload) {
+                return subscriber -> {
+                    Payload responsePayload = new Payload() {
+                        ByteBuffer data = ByteBuffer.wrap(response);
+                        ByteBuffer metadata = ByteBuffer.allocate(0);
+
+                        public ByteBuffer getData() {
+                            return data;
+                        }
+
                         @Override
-                        public void subscribe(Subscriber<? super Payload> s) {
-                            Payload responsePayload = new Payload() {
-                                ByteBuffer data = ByteBuffer.wrap(response);
-                                ByteBuffer metadata = ByteBuffer.allocate(0);
-
-                                public ByteBuffer getData() {
-                                    return data;
-                                }
-
-                                @Override
-                                public ByteBuffer getMetadata() {
-                                    return metadata;
-                                }
-                            };
-
-                            s.onNext(responsePayload);
-                            s.onComplete();
+                        public ByteBuffer getMetadata() {
+                            return metadata;
                         }
                     };
-                }
 
-                @Override
-                public Publisher<Payload> handleRequestStream(Payload payload) {
-                    Payload response =
-                        TestUtil.utf8EncodedPayload("hello world", "metadata");
-                    return RxReactiveStreams
-                        .toPublisher(Observable
-                            .range(1, 10)
-                            .map(i -> response));
-                }
+                    subscriber.onNext(responsePayload);
+                    subscriber.onComplete();
+                };
+            }
 
-                @Override
-                public Publisher<Payload> handleSubscription(Payload payload) {
-                    Payload response =
-                        TestUtil.utf8EncodedPayload("hello world", "metadata");
-                    return RxReactiveStreams
-                        .toPublisher(Observable
-                            .range(1, 10)
-                            .map(i -> response));
-                }
+            @Override
+            public Publisher<Payload> handleRequestStream(Payload payload) {
+                Payload response =
+                    TestUtil.utf8EncodedPayload("hello world", "metadata");
+                return RxReactiveStreams
+                    .toPublisher(Observable
+                        .range(1, 10)
+                        .map(i -> response));
+            }
 
-                @Override
-                public Publisher<Void> handleFireAndForget(Payload payload) {
-                    return Subscriber::onComplete;
-                }
+            @Override
+            public Publisher<Payload> handleSubscription(Payload payload) {
+                Payload response =
+                    TestUtil.utf8EncodedPayload("hello world", "metadata");
+                return RxReactiveStreams
+                    .toPublisher(Observable
+                        .range(1, 10)
+                        .map(i -> response));
+            }
 
-                @Override
-                public Publisher<Payload> handleChannel(Payload initialPayload, Publisher<Payload> inputs) {
-                    Observable<Payload> observable =
-                        RxReactiveStreams
-                            .toObservable(inputs)
-                            .map(input -> input);
-                    return RxReactiveStreams.toPublisher(observable);
+            @Override
+            public Publisher<Void> handleFireAndForget(Payload payload) {
+                return Subscriber::onComplete;
+            }
 
-//                    return outputSubscriber -> {
-//                        inputs.subscribe(new Subscriber<Payload>() {
-//                            private int count = 0;
-//                            private boolean completed = false;
-//
-//                            @Override
-//                            public void onSubscribe(Subscription s) {
-//                                //outputSubscriber.onSubscribe(s);
-//                                s.request(128);
-//                            }
-//
-//                            @Override
-//                            public void onNext(Payload input) {
-//                                if (completed) {
-//                                    return;
-//                                }
-//                                count += 1;
-//                                outputSubscriber.onNext(input);
-//                                outputSubscriber.onNext(input);
-//                                if (count > 10) {
-//                                    completed = true;
-//                                    outputSubscriber.onComplete();
-//                                }
-//                            }
-//
-//                            @Override
-//                            public void onError(Throwable t) {
-//                                if (!completed) {
-//                                    outputSubscriber.onError(t);
-//                                }
-//                            }
-//
-//                            @Override
-//                            public void onComplete() {
-//                                if (!completed) {
-//                                    outputSubscriber.onComplete();
-//                                }
-//                            }
-//                        });
-//                    };
-                }
+            @Override
+            public Publisher<Payload> handleChannel(Payload initialPayload, Publisher<Payload> inputs) {
+                Observable<Payload> observable =
+                    RxReactiveStreams
+                        .toObservable(inputs)
+                        .map(input -> input);
+                return RxReactiveStreams.toPublisher(observable);
+            }
 
-                @Override
-                public Publisher<Void> handleMetadataPush(Payload payload) {
-                    return null;
-                }
-            });
+            @Override
+            public Publisher<Void> handleMetadataPush(Payload payload) {
+                return null;
+            }
+        };
 
         EventLoopGroup bossGroup = new NioEventLoopGroup(1);
         EventLoopGroup workerGroup = new NioEventLoopGroup();
@@ -167,6 +122,8 @@ public class Pong {
                     pipeline.addLast(new HttpServerCodec());
                     pipeline.addLast(new HttpObjectAggregator(64 * 1024));
                     pipeline.addLast(new WebSocketServerProtocolHandler("/rs"));
+                    ReactiveSocketServerHandler serverHandler =
+                        ReactiveSocketServerHandler.create((setupPayload, rs) -> requestHandler);
                     pipeline.addLast(serverHandler);
                 }
             });


### PR DESCRIPTION
**Problem**
There's a memory leak in `ReactiveSocketServerHandler`, it keep adding entries
in the `duplexConnections` map but never remove them.

**Solution**
Instead of having only one `ReactiveSocketServerHandler`, and manage resources
manually, we let Netty allocate one instance per Channel. Then no resource
management is necessary.

**Modifications**
I refactored all the uages of `ReactiveSocketServerHandler` whithout changing
the logic. I also got rid of the method
```
public void channelReadComplete(ChannelHandlerContext ctx) {
    ctx.flush();
}
```
since we only use `writeAndFlush` in the DuplexConnection (we're sure there's
nothing to flush).