### PR TITLE
Fix subscription in DuplexConnection.

### DIFF
--- a/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/client/ClientTcpDuplexConnection.java
+++ b/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/client/ClientTcpDuplexConnection.java
@@ -72,9 +72,9 @@ public class ClientTcpDuplexConnection implements DuplexConnection {
                 }).connect(address);
 
             connect.addListener(connectFuture -> {
+                s.onSubscribe(EmptySubscription.INSTANCE);
                 if (connectFuture.isSuccess()) {
                     Channel ch = connect.channel();
-                    s.onSubscribe(EmptySubscription.INSTANCE);
                     s.onNext(new ClientTcpDuplexConnection(ch, subjects));
                     s.onComplete();
                 } else {

--- a/reactivesocket-transport-websocket/src/main/java/io/reactivesocket/transport/websocket/client/ClientWebSocketDuplexConnection.java
+++ b/reactivesocket-transport-websocket/src/main/java/io/reactivesocket/transport/websocket/client/ClientWebSocketDuplexConnection.java
@@ -91,8 +91,8 @@ public class ClientWebSocketDuplexConnection implements DuplexConnection {
                     clientHandler
                         .getHandshakePromise()
                         .addListener(handshakeFuture -> {
+                            s.onSubscribe(EmptySubscription.INSTANCE);
                             if (handshakeFuture.isSuccess()) {
-                                s.onSubscribe(EmptySubscription.INSTANCE);
                                 s.onNext(new ClientWebSocketDuplexConnection(ch, subjects));
                                 s.onComplete();
                             } else {


### PR DESCRIPTION
**Problem**
A Publisher may not have been initialized when a DuplexConnection failed during
the connection establishement. (e.g. connection reset by peer)

**Solution**
Do the subscription as soon as Netty complete, regarding of the result
of the ConnectFuture.