### PR TITLE
Wire `onSubscribe` in *Connector.

### DIFF
--- a/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/client/TcpReactiveSocketConnector.java
+++ b/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/client/TcpReactiveSocketConnector.java
@@ -45,10 +45,10 @@ public class TcpReactiveSocketConnector implements ReactiveSocketConnector<Socke
         Publisher<ClientTcpDuplexConnection> connection
             = ClientTcpDuplexConnection.create(address, eventLoopGroup);
 
-        return s -> connection.subscribe(new Subscriber<ClientTcpDuplexConnection>() {
+        return subscriber -> connection.subscribe(new Subscriber<ClientTcpDuplexConnection>() {
             @Override
             public void onSubscribe(Subscription s) {
-                s.request(1);
+                subscriber.onSubscribe(s);
             }
 
             @Override
@@ -58,21 +58,20 @@ public class TcpReactiveSocketConnector implements ReactiveSocketConnector<Socke
                 reactiveSocket.start(new Completable() {
                     @Override
                     public void success() {
-                        s.onSubscribe(EmptySubscription.INSTANCE);
-                        s.onNext(reactiveSocket);
-                        s.onComplete();
+                        subscriber.onNext(reactiveSocket);
+                        subscriber.onComplete();
                     }
 
                     @Override
                     public void error(Throwable e) {
-                        s.onError(e);
+                        subscriber.onError(e);
                     }
                 });
             }
 
             @Override
             public void onError(Throwable t) {
-                s.onError(t);
+                subscriber.onError(t);
             }
 
             @Override

--- a/reactivesocket-transport-websocket/src/main/java/io/reactivesocket/transport/websocket/client/WebSocketReactiveSocketConnector.java
+++ b/reactivesocket-transport-websocket/src/main/java/io/reactivesocket/transport/websocket/client/WebSocketReactiveSocketConnector.java
@@ -53,10 +53,10 @@ public class WebSocketReactiveSocketConnector implements ReactiveSocketConnector
             Publisher<ClientWebSocketDuplexConnection> connection
                     = ClientWebSocketDuplexConnection.create((InetSocketAddress)address, path, eventLoopGroup);
 
-            return s -> connection.subscribe(new Subscriber<ClientWebSocketDuplexConnection>() {
+            return subscriber -> connection.subscribe(new Subscriber<ClientWebSocketDuplexConnection>() {
                 @Override
                 public void onSubscribe(Subscription s) {
-                    s.request(1);
+                    subscriber.onSubscribe(s);
                 }
 
                 @Override
@@ -65,26 +65,25 @@ public class WebSocketReactiveSocketConnector implements ReactiveSocketConnector
                     reactiveSocket.start(new Completable() {
                         @Override
                         public void success() {
-                            s.onSubscribe(EmptySubscription.INSTANCE);
-                            s.onNext(reactiveSocket);
-                            s.onComplete();
+                            subscriber.onNext(reactiveSocket);
+                            subscriber.onComplete();
                         }
 
                         @Override
                         public void error(Throwable e) {
-                            s.onError(e);
+                            subscriber.onError(e);
                         }
                     });
                 }
 
                 @Override
                 public void onError(Throwable t) {
-                    s.onError(t);
+                    subscriber.onError(t);
                 }
 
                 @Override
                 public void onComplete() {
-                    s.onComplete();
+                    subscriber.onComplete();
                 }
             });
         } else {


### PR DESCRIPTION
**Problem**
Instead of manually requesting in the `onSubscribe`, it's better
to actually pass the `Subscription` to the `Subscriber`.
The *Connector code was a little bit confusing because the `Subscriber`
like the `Subscription` were names `s`.

**Solution**
Rename the `Subscriber` -> `subscriber`, and pass the subscription.