### PR TITLE
Unsubscribe from the connection before `shutdown` the RS.

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/DefaultReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/DefaultReactiveSocket.java
@@ -454,7 +454,6 @@ public class DefaultReactiveSocket implements ReactiveSocket {
     @Override
     public void close() throws Exception {
         try {
-            connection.close();
             leaseGovernor.unregister(responder);
             if (requester != null) {
                 requester.shutdown();
@@ -462,9 +461,8 @@ public class DefaultReactiveSocket implements ReactiveSocket {
             if (responder != null) {
                 responder.shutdown();
             }
-
+            connection.close();
             shutdownListeners.forEach(Completable::success);
-
         } catch (Throwable t) {
             shutdownListeners.forEach(c -> c.error(t));
             throw t;

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
@@ -52,24 +52,23 @@ import org.agrona.collections.Int2ObjectHashMap;
  * Concrete implementations of {@link DuplexConnection} over TCP, WebSockets, Aeron, etc can be passed to this class for protocol handling.
  */
 public class Requester {
-
-    private final static Disposable CANCELLED = new EmptyDisposable();
-    private final static int KEEPALIVE_INTERVAL_MS = 1000;
+    private static final Disposable CANCELLED = new EmptyDisposable();
+    private static final int KEEPALIVE_INTERVAL_MS = 1000;
+    private static final long DEFAULT_BATCH = 1024;
+    private static final long REQUEST_THRESHOLD = 256;
 
     private final boolean isServer;
     private final DuplexConnection connection;
     private final Int2ObjectHashMap<UnicastSubject<Frame>> streamInputMap = new Int2ObjectHashMap<>();
     private final ConnectionSetupPayload setupPayload;
     private final Consumer<Throwable> errorStream;
-
     private final boolean honorLease;
+
     private long ttlExpiration;
     private long numberOfRemainingRequests = 0;
     private long timeOfLastKeepalive = 0;
     private int streamCount = 0; // 0 is reserved for setup, all normal messages are >= 1
-
-    private static final long DEFAULT_BATCH = 1024;
-    private static final long REQUEST_THRESHOLD = 256;
+    private AtomicReference<Disposable> connectionSubscription = new AtomicReference<>();
 
     private volatile boolean requesterStarted = false;
 
@@ -115,8 +114,10 @@ public class Requester {
     }
 
     public void shutdown() {
-        // TODO do something here
-        System.err.println("**** Requester.shutdown => this should actually do something");
+        Disposable disposable = connectionSubscription.getAndSet(CANCELLED);
+        if (disposable != null && disposable != CANCELLED) {
+            disposable.dispose();
+        }
     }
 
     public boolean isServer() {
@@ -163,7 +164,7 @@ public class Requester {
      */
     public Publisher<Void> fireAndForget(final Payload payload) {
         if (payload == null) {
-            throw new IllegalStateException("Payload can not be null");
+            throw new IllegalStateException(name() + " Payload can not be null");
         }
         assertStarted();
         return child -> child.onSubscribe(new Subscription() {
@@ -211,7 +212,7 @@ public class Requester {
      */
     public Publisher<Void> metadataPush(final Payload payload) {
         if (payload == null) {
-            throw new IllegalArgumentException("Payload can not be null");
+            throw new IllegalArgumentException(name() + " Payload can not be null");
         }
         assertStarted();
         return (Subscriber<? super Void> child) ->
@@ -273,7 +274,7 @@ public class Requester {
 
     private void assertStarted() {
         if (!requesterStarted) {
-            throw new IllegalStateException("Requester not initialized. " +
+            throw new IllegalStateException(name() + " Requester not initialized. " +
                 "Please await 'start()' completion before submitting requests.");
         }
     }
@@ -411,7 +412,7 @@ public class Requester {
         Publisher<Payload> payloads
     ) {
         if (payloads == null) {
-            throw new IllegalStateException("Both payload and payloads can not be null");
+            throw new IllegalStateException(name() + " Both payload and payloads can not be null");
         }
         assertStarted();
         return (Subscriber<? super Payload> child) -> {
@@ -497,7 +498,7 @@ public class Requester {
                                                     public void onError(Throwable t) {
                                                         // TODO validate with unit tests
                                                         RuntimeException exc = new RuntimeException(
-                                                            "Error received from request stream.", t);
+                                                            name() + " Error received from request stream.", t);
                                                         transport.onError(exc);
                                                         child.onError(exc);
                                                         cancel();
@@ -617,7 +618,7 @@ public class Requester {
      */
     private Publisher<Payload> startRequestResponse(int streamId, FrameType type, Payload payload) {
         if (payload == null) {
-            throw new IllegalStateException("Both payload and payloads can not be null");
+            throw new IllegalStateException(name() + " Both payload and payloads can not be null");
         }
         assertStarted();
         return (Subscriber<? super Payload> child) -> {
@@ -837,7 +838,6 @@ public class Requester {
     }
 
     private void start(Completable onComplete) {
-        AtomicReference<Disposable> connectionSubscription = new AtomicReference<>();
         // get input from responder->requestor for responses
         connection.getInput().subscribe(new Observer<Frame>() {
             public void onSubscribe(Disposable d) {
@@ -888,7 +888,7 @@ public class Requester {
                 } else {
                     // means we already were cancelled
                     d.dispose();
-                    onComplete.error(new CancelException("Connection Is Already Cancelled"));
+                    onComplete.error(new CancelException(name() + " Connection Is Already Cancelled"));
                 }
             }
 
@@ -916,7 +916,7 @@ public class Requester {
                         timeOfLastKeepalive = System.currentTimeMillis();
                     } else {
                         onError(new RuntimeException(
-                            "Received unexpected message type on stream 0: " + frame.getType().name()));
+                            name() + " Received unexpected message type on stream 0: " + frame.getType().name()));
                     }
                 } else {
                     UnicastSubject<Frame> streamSubject;
@@ -934,11 +934,11 @@ public class Requester {
                             if (frame.getType() == FrameType.ERROR) {
                                 String errorMessage = getByteBufferAsString(frame.getData());
                                 onError(new RuntimeException(
-                                    "Received error for non-existent stream: "
+                                    name() + " Received error for non-existent stream: "
                                         + streamId + " Message: " + errorMessage));
                             } else {
                                 onError(new RuntimeException(
-                                    "Received message for non-existent stream: " + streamId));
+                                    name() + " Received message for non-existent stream: " + streamId));
                             }
                         }
                     } else {
@@ -979,6 +979,14 @@ public class Requester {
                 }
             }
         });
+    }
+
+    private String name() {
+        if (isServer) {
+            return "ServerRequester";
+        } else {
+            return "ClientRequester";
+        }
     }
 
     private static String getByteBufferAsString(ByteBuffer bb) {

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
@@ -115,7 +115,7 @@ public class Requester {
 
     public void shutdown() {
         Disposable disposable = connectionSubscription.getAndSet(CANCELLED);
-        if (disposable != null && disposable != CANCELLED) {
+        if (disposable != null) {
             disposable.dispose();
         }
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/Responder.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/Responder.java
@@ -365,9 +365,7 @@ public class Responder {
 			public void onError(Throwable t) {
 				// TODO validate with unit tests
 				if (childTerminated.compareAndSet(false, true)) {
-					if (!(t instanceof ClosedChannelException)) {
-						errorStream.accept(t);
-					}
+					errorStream.accept(t);
 					cancel();
 				}
 			}


### PR DESCRIPTION
**Problem**
When we close a ReactiveSocket, it closes the underlying DuplexConnection
which trigger an unnecessary onError on the Requester/Responder.

**Solution**
Store the disposable of the DuplexConnection subscription as an instance
variable, and dispose it before closing the DuplexConnection.

**Modification**
I also added a `name` method in Requester/Responder to simplify debugging
code where we have client and server in the same JVM.
It now shows which Requester/Responder is generating an error, the client's
one or the server's one.