### PR TITLE
use charset consistently

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
@@ -27,7 +27,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static java.lang.System.getProperty;
 
@@ -318,7 +318,7 @@ public class Frame implements Payload {
             ByteBuffer metadata
         ) {
             String data = throwable.getMessage() == null ? "" : throwable.getMessage();
-            byte[] bytes = data.getBytes(Charset.forName("UTF-8"));
+            byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
             final ByteBuffer dataBuffer = ByteBuffer.wrap(bytes);
 
             return from(streamId, throwable, metadata, dataBuffer);
@@ -533,14 +533,14 @@ public class Frame implements Payload {
             if (0 < byteBuffer.capacity()) {
                 bytes = new byte[byteBuffer.capacity()];
                 byteBuffer.get(bytes);
-                payload.append(String.format("metadata: \"%s\" ", new String(bytes, Charset.forName("UTF-8"))));
+                payload.append(String.format("metadata: \"%s\" ", new String(bytes, StandardCharsets.UTF_8)));
             }
 
             byteBuffer = FrameHeaderFlyweight.sliceFrameData(directBuffer, 0, 0);
             if (0 < byteBuffer.capacity()) {
                 bytes = new byte[byteBuffer.capacity()];
                 byteBuffer.get(bytes);
-                payload.append(String.format("data: \"%s\"", new String(bytes, Charset.forName("UTF-8"))));
+                payload.append(String.format("data: \"%s\"", new String(bytes, StandardCharsets.UTF_8)));
             }
 
             streamId = FrameHeaderFlyweight.streamId(directBuffer, 0);

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/Exceptions.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/Exceptions.java
@@ -30,9 +30,15 @@ public class Exceptions {
         final int errorCode = Frame.Error.errorCode(frame);
         String message = "<empty message>";
         final ByteBuffer byteBuffer = frame.getMetadata();
-        if (byteBuffer.hasArray()) {
-            message = new String(byteBuffer.array(), UTF_8);
+
+        // TODO nasty, but it seems strange to assume ByteBuffer is array backed
+        byte[] bytes = new byte[byteBuffer.remaining()];
+        byteBuffer.get(bytes, 0, bytes.length);
+        int length = bytes.length;
+        if (length > 1 && bytes[length - 1] == 0) {
+            length--;
         }
+        message = new String(bytes, 0, length, UTF_8);
 
         Throwable ex;
         switch (errorCode) {

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/Exceptions.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/Exceptions.java
@@ -29,7 +29,7 @@ public class Exceptions {
     public static Throwable from(Frame frame) {
         final int errorCode = Frame.Error.errorCode(frame);
         ByteBuffer dataBuffer = frame.getData();
-        String message = dataBuffer.remaining() == 0 ? "<empty message>" : ByteBufferUtil.toUtfString(dataBuffer);
+        String message = dataBuffer.remaining() == 0 ? "<empty message>" : ByteBufferUtil.toUtf8String(dataBuffer);
 
         Throwable ex;
         switch (errorCode) {

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/Exceptions.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/Exceptions.java
@@ -29,7 +29,7 @@ public class Exceptions {
     public static Throwable from(Frame frame) {
         final int errorCode = Frame.Error.errorCode(frame);
         String message = "<empty message>";
-        final ByteBuffer byteBuffer = frame.getMetadata();
+        final ByteBuffer byteBuffer = frame.getData();
 
         // TODO nasty, but it seems strange to assume ByteBuffer is array backed
         byte[] bytes = new byte[byteBuffer.remaining()];

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/Exceptions.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/Exceptions.java
@@ -16,11 +16,11 @@
 package io.reactivesocket.exceptions;
 
 import io.reactivesocket.Frame;
+import io.reactivesocket.internal.frame.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 
 import static io.reactivesocket.internal.frame.ErrorFrameFlyweight.*;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Exceptions {
 
@@ -28,17 +28,8 @@ public class Exceptions {
 
     public static Throwable from(Frame frame) {
         final int errorCode = Frame.Error.errorCode(frame);
-        String message = "<empty message>";
-        final ByteBuffer byteBuffer = frame.getData();
-
-        // TODO nasty, but it seems strange to assume ByteBuffer is array backed
-        byte[] bytes = new byte[byteBuffer.remaining()];
-        byteBuffer.get(bytes, 0, bytes.length);
-        int length = bytes.length;
-        if (length > 1 && bytes[length - 1] == 0) {
-            length--;
-        }
-        message = new String(bytes, 0, length, UTF_8);
+        ByteBuffer dataBuffer = frame.getData();
+        String message = dataBuffer.remaining() == 0 ? "<empty message>" : ByteBufferUtil.toUtfString(dataBuffer);
 
         Throwable ex;
         switch (errorCode) {

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/PublisherUtils.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/PublisherUtils.java
@@ -16,6 +16,7 @@
 package io.reactivesocket.internal;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -81,7 +82,7 @@ public class PublisherUtils {
 
 							@Override
 							public ByteBuffer getData() {
-								final byte[] bytes = e.getMessage().getBytes();
+								final byte[] bytes = e.getMessage().getBytes(StandardCharsets.UTF_8);
 								final ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
 								return byteBuffer;
 							}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
@@ -17,7 +17,7 @@ package io.reactivesocket.internal;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -992,6 +992,6 @@ public class Requester {
     private static String getByteBufferAsString(ByteBuffer bb) {
         final byte[] bytes = new byte[bb.capacity()];
         bb.get(bytes);
-        return new String(bytes, Charset.forName("UTF-8"));
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Netflix, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,10 +17,12 @@ package io.reactivesocket.internal.frame;
 
 import java.nio.ByteBuffer;
 
-public class ByteBufferUtil
-{
+import static java.nio.charset.StandardCharsets.UTF_8;
 
-    private ByteBufferUtil() {}
+public class ByteBufferUtil {
+
+    private ByteBufferUtil() {
+    }
 
     /**
      * Slice a portion of the {@link ByteBuffer} while preserving the buffers position and limit.
@@ -30,10 +32,9 @@ public class ByteBufferUtil
      * @param byteBuffer to slice off of
      * @param position   to start slice at
      * @param limit      to slice to
-     * @return           slice of byteBuffer with passed ByteBuffer preserved position and limit.
+     * @return slice of byteBuffer with passed ByteBuffer preserved position and limit.
      */
-    public static ByteBuffer preservingSlice(final ByteBuffer byteBuffer, final int position, final int limit)
-    {
+    public static ByteBuffer preservingSlice(final ByteBuffer byteBuffer, final int position, final int limit) {
         final int savedPosition = byteBuffer.position();
         final int savedLimit = byteBuffer.limit();
 
@@ -43,5 +44,11 @@ public class ByteBufferUtil
 
         byteBuffer.limit(savedLimit).position(savedPosition);
         return result;
+    }
+
+    public static String toUtfString(ByteBuffer byteBuffer) {
+        byte[] bytes = new byte[byteBuffer.remaining()];
+        byteBuffer.get(bytes);
+        return new String(bytes, UTF_8);
     }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
@@ -25,7 +25,7 @@ public class ByteBufferUtil
     /**
      * Slice a portion of the {@link ByteBuffer} while preserving the buffers position and limit.
      *
-     * NOTE: Missing functionaity from {@link ByteBuffer}
+     * NOTE: Missing functionality from {@link ByteBuffer}
      *
      * @param byteBuffer to slice off of
      * @param position   to start slice at

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
@@ -46,7 +46,7 @@ public class ByteBufferUtil {
         return result;
     }
 
-    public static String toUtfString(ByteBuffer byteBuffer) {
+    public static String toUtf8String(ByteBuffer byteBuffer) {
         byte[] bytes = new byte[byteBuffer.remaining()];
         byteBuffer.get(bytes);
         return new String(bytes, UTF_8);

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
@@ -22,7 +22,7 @@ import org.agrona.MutableDirectBuffer;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class SetupFrameFlyweight
 {
@@ -102,7 +102,7 @@ public class SetupFrameFlyweight
     public static String metadataMimeType(final DirectBuffer directBuffer, final int offset)
     {
         final byte[] bytes = getMimeType(directBuffer, offset + METADATA_MIME_TYPE_LENGTH_OFFSET);
-        return new String(bytes, Charset.forName("UTF-8"));
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     public static String dataMimeType(final DirectBuffer directBuffer, final int offset)
@@ -112,7 +112,7 @@ public class SetupFrameFlyweight
         fieldOffset += 1 + directBuffer.getByte(fieldOffset);
 
         final byte[] bytes = getMimeType(directBuffer, fieldOffset);
-        return new String(bytes, Charset.forName("UTF-8"));
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     public static int computePayloadOffset(
@@ -140,7 +140,7 @@ public class SetupFrameFlyweight
         final MutableDirectBuffer mutableDirectBuffer, final int fieldOffset, final String mimeType)
     {
         mutableDirectBuffer.putByte(fieldOffset, (byte) mimeType.length());
-        mutableDirectBuffer.putBytes(fieldOffset + 1, mimeType.getBytes());
+        mutableDirectBuffer.putBytes(fieldOffset + 1, mimeType.getBytes(StandardCharsets.UTF_8));
 
         return 1 + mimeType.length();
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
@@ -102,7 +102,10 @@ public class SetupFrameFlyweight
     public static String metadataMimeType(final DirectBuffer directBuffer, final int offset)
     {
         final byte[] bytes = getMimeType(directBuffer, offset + METADATA_MIME_TYPE_LENGTH_OFFSET);
-        return new String(bytes, StandardCharsets.UTF_8);
+        int length = bytes.length;
+        if (length > 0 && bytes[length - 1] == 0)
+            length --;
+        return new String(bytes, 0, length, StandardCharsets.US_ASCII);
     }
 
     public static String dataMimeType(final DirectBuffer directBuffer, final int offset)
@@ -112,7 +115,10 @@ public class SetupFrameFlyweight
         fieldOffset += 1 + directBuffer.getByte(fieldOffset);
 
         final byte[] bytes = getMimeType(directBuffer, fieldOffset);
-        return new String(bytes, StandardCharsets.UTF_8);
+        int length = bytes.length;
+        if (length > 0 && bytes[length - 1] == 0)
+            length --;
+        return new String(bytes, 0, length, StandardCharsets.US_ASCII);
     }
 
     public static int computePayloadOffset(
@@ -140,7 +146,7 @@ public class SetupFrameFlyweight
         final MutableDirectBuffer mutableDirectBuffer, final int fieldOffset, final String mimeType)
     {
         mutableDirectBuffer.putByte(fieldOffset, (byte) mimeType.length());
-        mutableDirectBuffer.putBytes(fieldOffset + 1, mimeType.getBytes(StandardCharsets.UTF_8));
+        mutableDirectBuffer.putBytes(fieldOffset + 1, mimeType.getBytes(StandardCharsets.US_ASCII));
 
         return 1 + mimeType.length();
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
@@ -48,8 +48,8 @@ public class SetupFrameFlyweight
         int length = FrameHeaderFlyweight.computeFrameHeaderLength(FrameType.SETUP, metadataLength, dataLength);
 
         length += BitUtil.SIZE_OF_INT * 3;
-        length += 1 + metadataMimeType.length();
-        length += 1 + dataMimeType.length();
+        length += 1 + metadataMimeType.getBytes(StandardCharsets.UTF_8).length;
+        length += 1 + dataMimeType.getBytes(StandardCharsets.UTF_8).length;
 
         return length;
     }
@@ -102,10 +102,7 @@ public class SetupFrameFlyweight
     public static String metadataMimeType(final DirectBuffer directBuffer, final int offset)
     {
         final byte[] bytes = getMimeType(directBuffer, offset + METADATA_MIME_TYPE_LENGTH_OFFSET);
-        int length = bytes.length;
-        if (length > 0 && bytes[length - 1] == 0)
-            length --;
-        return new String(bytes, 0, length, StandardCharsets.US_ASCII);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     public static String dataMimeType(final DirectBuffer directBuffer, final int offset)
@@ -115,18 +112,7 @@ public class SetupFrameFlyweight
         fieldOffset += 1 + directBuffer.getByte(fieldOffset);
 
         final byte[] bytes = getMimeType(directBuffer, fieldOffset);
-        int length = bytes.length;
-        if (length > 0 && bytes[length - 1] == 0)
-            length --;
-        return new String(bytes, 0, length, StandardCharsets.US_ASCII);
-    }
-
-    public static int computePayloadOffset(
-        final int offset, final int metadataMimeTypeLength, final int dataMimeTypeLength)
-    {
-        return offset + METADATA_MIME_TYPE_LENGTH_OFFSET +
-            1 + metadataMimeTypeLength +
-            1 + dataMimeTypeLength;
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     public static int payloadOffset(final DirectBuffer directBuffer, final int offset)
@@ -145,10 +131,12 @@ public class SetupFrameFlyweight
     private static int putMimeType(
         final MutableDirectBuffer mutableDirectBuffer, final int fieldOffset, final String mimeType)
     {
-        mutableDirectBuffer.putByte(fieldOffset, (byte) mimeType.length());
-        mutableDirectBuffer.putBytes(fieldOffset + 1, mimeType.getBytes(StandardCharsets.US_ASCII));
+        byte[] bytes = mimeType.getBytes(StandardCharsets.UTF_8);
 
-        return 1 + mimeType.length();
+        mutableDirectBuffer.putByte(fieldOffset, (byte) bytes.length);
+        mutableDirectBuffer.putBytes(fieldOffset + 1, bytes);
+
+        return 1 + bytes.length;
     }
 
     private static byte[] getMimeType(final DirectBuffer directBuffer, final int fieldOffset)

--- a/reactivesocket-core/src/perf/java/io/reactivesocket/FramePerf.java
+++ b/reactivesocket-core/src/perf/java/io/reactivesocket/FramePerf.java
@@ -16,9 +16,9 @@
 package io.reactivesocket;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.math3.stat.inference.TestUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -34,7 +34,7 @@ public class FramePerf {
 
 	public static Frame utf8EncodedFrame(final int streamId, final FrameType type, final String data)
 	{
-		final byte[] bytes = data.getBytes();
+		final byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
 		final ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
 		final Payload payload = new Payload()
 		{
@@ -83,7 +83,7 @@ public class FramePerf {
 		 */
 		public Blackhole bh;
 		
-		public ByteBuffer HELLO = ByteBuffer.wrap("HELLO".getBytes());
+		public ByteBuffer HELLO = ByteBuffer.wrap("HELLO".getBytes(StandardCharsets.UTF_8));
 		public Payload HELLOpayload = new Payload()
 		{
 			public ByteBuffer getData()

--- a/reactivesocket-core/src/perf/java/io/reactivesocket/ReactiveSocketPerf.java
+++ b/reactivesocket-core/src/perf/java/io/reactivesocket/ReactiveSocketPerf.java
@@ -16,6 +16,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -48,8 +49,8 @@ public class ReactiveSocketPerf {
 		 */
 		public Blackhole bh;
 
-		static final ByteBuffer HELLO = ByteBuffer.wrap("HELLO".getBytes());
-		static final ByteBuffer HELLO_WORLD = ByteBuffer.wrap("HELLO_WORLD".getBytes());
+		static final ByteBuffer HELLO = ByteBuffer.wrap("HELLO".getBytes(StandardCharsets.UTF_8));
+		static final ByteBuffer HELLO_WORLD = ByteBuffer.wrap("HELLO_WORLD".getBytes(StandardCharsets.UTF_8));
 		static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
 
 		static final Payload HELLO_PAYLOAD = new Payload() {

--- a/reactivesocket-core/src/test/java/io/reactivesocket/FrameTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/FrameTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
+import io.reactivesocket.exceptions.Exceptions;
 import io.reactivesocket.exceptions.RejectedException;
 import io.reactivesocket.internal.frame.SetupFrameFlyweight;
 
@@ -452,10 +453,12 @@ public class FrameTest
         TestUtil.copyFrame(reusableMutableDirectBuffer, offset, encodedFrame);
         reusableFrame.wrap(reusableMutableDirectBuffer, offset);
 
-
         assertEquals(FrameType.ERROR, reusableFrame.getType());
         assertEquals(exMessage, TestUtil.byteToString(reusableFrame.getData()));
         assertEquals(TestUtil.byteBufferFromUtf8String(metadata), reusableFrame.getMetadata());
+
+        final Throwable throwable = Exceptions.from(encodedFrame);
+        assertEquals(exMessage, throwable.getMessage());
     }
 
     @Test

--- a/reactivesocket-core/src/test/java/io/reactivesocket/TestUtil.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/TestUtil.java
@@ -18,7 +18,7 @@ package io.reactivesocket;
 import org.agrona.MutableDirectBuffer;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class TestUtil
 {
@@ -59,12 +59,12 @@ public class TestUtil
     {
         final byte[] bytes = new byte[byteBuffer.remaining()];
         byteBuffer.get(bytes);
-        return new String(bytes, Charset.forName("UTF-8"));
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     public static ByteBuffer byteBufferFromUtf8String(final String data)
     {
-        final byte[] bytes = data.getBytes(Charset.forName("UTF-8"));
+        final byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
         return ByteBuffer.wrap(bytes);
     }
 

--- a/reactivesocket-mime-types/src/main/java/io/reactivesocket/mimetypes/internal/cbor/MetadataCodec.java
+++ b/reactivesocket-mime-types/src/main/java/io/reactivesocket/mimetypes/internal/cbor/MetadataCodec.java
@@ -25,6 +25,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map.Entry;
 
 import static io.reactivesocket.mimetypes.internal.cbor.CBORUtils.*;
@@ -139,8 +140,9 @@ public class MetadataCodec implements Codec {
     private static int getSizeAsBytes(KVMetadata toEncode) {
         int toReturn = 1 + (int) getEncodeLength(toEncode.size()); // Map Starting + break
         for (Entry<String, ByteBuffer> entry : toEncode.entrySet()) {
-            toReturn += getEncodeLength(entry.getKey().length());
-            toReturn += entry.getKey().length();
+            int keyLength = entry.getKey().getBytes(StandardCharsets.UTF_8).length;
+            toReturn += getEncodeLength(keyLength);
+            toReturn += keyLength;
 
             int valueLength = entry.getValue().remaining();
             toReturn += getEncodeLength(valueLength);

--- a/reactivesocket-mime-types/src/test/java/io/reactivesocket/mimetypes/internal/MetadataRule.java
+++ b/reactivesocket-mime-types/src/test/java/io/reactivesocket/mimetypes/internal/MetadataRule.java
@@ -46,8 +46,9 @@ public class MetadataRule extends ExternalResource {
     }
 
     public void addMetadata(String key, String value) {
-        ByteBuffer allocate = ByteBuffer.allocate(value.length());
-        allocate.put(value.getBytes(StandardCharsets.UTF_8)).flip();
+        byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer allocate = ByteBuffer.allocate(valueBytes.length);
+        allocate.put(valueBytes).flip();
         kvMetadata.put(key, allocate);
     }
 

--- a/reactivesocket-mime-types/src/test/java/io/reactivesocket/mimetypes/internal/cbor/CborUtf8StringCodecTest.java
+++ b/reactivesocket-mime-types/src/test/java/io/reactivesocket/mimetypes/internal/cbor/CborUtf8StringCodecTest.java
@@ -28,6 +28,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -80,6 +81,6 @@ public class CborUtf8StringCodecTest {
     private static String newString(int stringLength) {
         byte[] b = new byte[stringLength];
         Arrays.fill(b, (byte) 'a');
-        return new String(b);
+        return new String(b, StandardCharsets.UTF_8);
     }
 }

--- a/reactivesocket-mime-types/src/test/java/io/reactivesocket/mimetypes/internal/cbor/MetadataCodecTest.java
+++ b/reactivesocket-mime-types/src/test/java/io/reactivesocket/mimetypes/internal/cbor/MetadataCodecTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -139,7 +140,7 @@ public class MetadataCodecTest {
         }
 
         public void addTestData(String key, String value) {
-            ByteBuffer vBuff = ByteBuffer.allocate(value.length()).put(value.getBytes());
+            ByteBuffer vBuff = ByteBuffer.allocate(value.length()).put(value.getBytes(StandardCharsets.UTF_8));
             vBuff.flip();
             testDataHolder.put(key, vBuff);
         }

--- a/reactivesocket-test/src/main/java/io/reactivesocket/test/TestUtil.java
+++ b/reactivesocket-test/src/main/java/io/reactivesocket/test/TestUtil.java
@@ -19,16 +19,9 @@ import io.reactivesocket.Frame;
 import io.reactivesocket.FrameType;
 import io.reactivesocket.Payload;
 import org.agrona.MutableDirectBuffer;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 
 public class TestUtil
 {
@@ -67,7 +60,7 @@ public class TestUtil
         ByteBuffer data = payload.getData();
         byte[] dst = new byte[data.remaining()];
         data.get(dst);
-        return new String(dst);
+        return new String(dst, StandardCharsets.UTF_8);
     }
 
     public static String byteToString(ByteBuffer byteBuffer)

--- a/reactivesocket-transport-tcp/src/test/java/io/reactivesocket/transport/tcp/Ping.java
+++ b/reactivesocket-transport-tcp/src/test/java/io/reactivesocket/transport/tcp/Ping.java
@@ -27,6 +27,7 @@ import rx.schedulers.Schedulers;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -42,7 +43,7 @@ public final class Ping {
                                  .toBlocking()
                                  .value();
 
-        byte[] data = "hello".getBytes();
+        byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
 
         Payload keyPayload = new Payload() {
             @Override

--- a/reactivesocket-transport-websocket/src/test/java/io/reactivesocket/transport/websocket/Ping.java
+++ b/reactivesocket-transport-websocket/src/test/java/io/reactivesocket/transport/websocket/Ping.java
@@ -30,6 +30,7 @@ import rx.schedulers.Schedulers;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -48,7 +49,7 @@ public class Ping {
 
         reactiveSocket.startAndWait();
 
-        byte[] data = "hello".getBytes();
+        byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
 
         Payload keyPayload = new Payload() {
             @Override


### PR DESCRIPTION
I don't like this PR, so using it for discussion.

The spec says

> Encoding MIME Type: MIME Type for encoding of Data and Metadata. This MAY be a US-ASCII string that includes the Internet media type specified in RFC 2045. Many are registered with IANA such as CBOR. Suffix rules MAY be used for handling layout. For example, application/x.netflix+cbor or application/x.reactivesocket+cbor or application/x.netflix+json. The string may or may not be null terminated.

Does this actually mean:  "This MAY be a Internet media type specified in RFC 2045.  If present, the value MUST be US-ASCII.".  If it can be UTF-8 then string.length() may not be the byte length.

Also can we change the spec to say that the string MUST NOT be null terminated.  we need to string before creating strings.  I assume this is useful if we want to have 0-copy strings in C++.  But we create these garbage strings in Java anyway...

I'll add tests once this is agreed.