### PR TITLE
Completing subscriber after sending error frame (caused memory leak).

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/Responder.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/Responder.java
@@ -75,10 +75,10 @@ public class Responder {
         this.isServer = isServer;
         this.connection = connection;
         this.connectionHandler = connectionHandler;
-        clientRequestHandler = requestHandler;
+        this.clientRequestHandler = requestHandler;
         this.leaseGovernor = leaseGovernor;
         this.errorStream = errorStream;
-        timeOfLastKeepalive = System.nanoTime();
+        this.timeOfLastKeepalive = System.nanoTime();
         this.setupCallback = setupCallback;
     }
 


### PR DESCRIPTION
#### Problem

In some cases, `Responder` was converting an `onError()` to `onNext(Frame.Error)` but was not sending an `onComplete()` after the `onNext()`.
This causes the `subscriber` to wait for a terminal event, which never arrives, or if it arrives, does not find the `streamId` to be valid since the code was invoking `cleanUp()`.
This although subtle, but causes memory build up as the `Subscriber` in the case of a server, is the subscriber which is writing the response. If the response does not complete, all state associated with the request is kept alive forever.

#### Solution

Call `onComplete()` after sending an error frame.

This code does not call `cancel()` after `onComplete()` as reactive streams spec does not mandate cancellation post a terminal event, unlike `RxJava`.

#### Result

No more memory leak!