### PR TITLE
use remaining instead of capacity generally

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
@@ -530,15 +530,15 @@ public class Frame implements Payload {
             byte[] bytes;
 
             byteBuffer = FrameHeaderFlyweight.sliceFrameMetadata(directBuffer, 0, 0);
-            if (0 < byteBuffer.capacity()) {
-                bytes = new byte[byteBuffer.capacity()];
+            if (0 < byteBuffer.remaining()) {
+                bytes = new byte[byteBuffer.remaining()];
                 byteBuffer.get(bytes);
                 payload.append(String.format("metadata: \"%s\" ", new String(bytes, StandardCharsets.UTF_8)));
             }
 
             byteBuffer = FrameHeaderFlyweight.sliceFrameData(directBuffer, 0, 0);
-            if (0 < byteBuffer.capacity()) {
-                bytes = new byte[byteBuffer.capacity()];
+            if (0 < byteBuffer.remaining()) {
+                bytes = new byte[byteBuffer.remaining()];
                 byteBuffer.get(bytes);
                 payload.append(String.format("data: \"%s\"", new String(bytes, StandardCharsets.UTF_8)));
             }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
@@ -990,7 +990,7 @@ public class Requester {
     }
 
     private static String getByteBufferAsString(ByteBuffer bb) {
-        final byte[] bytes = new byte[bb.capacity()];
+        final byte[] bytes = new byte[bb.remaining()];
         bb.get(bytes);
         return new String(bytes, StandardCharsets.UTF_8);
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/FrameHeaderFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/FrameHeaderFlyweight.java
@@ -120,7 +120,7 @@ public class FrameHeaderFlyweight
             int flags = mutableDirectBuffer.getShort(frameHeaderStartOffset + FLAGS_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
             flags |= FLAGS_M;
             mutableDirectBuffer.putShort(frameHeaderStartOffset + FLAGS_FIELD_OFFSET, (short)flags, ByteOrder.BIG_ENDIAN);
-            mutableDirectBuffer.putInt(metadataOffset, metadata.capacity() + BitUtil.SIZE_OF_INT, ByteOrder.BIG_ENDIAN);
+            mutableDirectBuffer.putInt(metadataOffset, metadataLength + BitUtil.SIZE_OF_INT, ByteOrder.BIG_ENDIAN);
             length += BitUtil.SIZE_OF_INT;
             mutableDirectBuffer.putBytes(metadataOffset + length, metadata, metadataLength);
             length += metadataLength;
@@ -137,7 +137,7 @@ public class FrameHeaderFlyweight
         int length = 0;
         final int dataLength = data.remaining();
 
-        if (0 < data.capacity())
+        if (0 < dataLength)
         {
             mutableDirectBuffer.putBytes(dataOffset, data, dataLength);
             length += dataLength;

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/PayloadBuilder.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/PayloadBuilder.java
@@ -69,18 +69,18 @@ public class PayloadBuilder
 
     public void append(final Payload payload)
     {
-        final ByteBuffer payloadData = payload.getData();
         final ByteBuffer payloadMetadata = payload.getMetadata();
-        final int dataLength = payloadData.remaining();
+        final ByteBuffer payloadData = payload.getData();
         final int metadataLength = payloadMetadata.remaining();
+        final int dataLength = payloadData.remaining();
 
-        ensureDataCapacity(dataLength);
         ensureMetadataCapacity(metadataLength);
+        ensureDataCapacity(dataLength);
 
-        dataMutableDirectBuffer.putBytes(dataLimit, payloadData, payloadData.capacity());
-        dataLimit += dataLength;
-        metadataMutableDirectBuffer.putBytes(metadataLimit, payloadMetadata, payloadMetadata.capacity());
+        metadataMutableDirectBuffer.putBytes(metadataLimit, payloadMetadata, metadataLength);
         metadataLimit += metadataLength;
+        dataMutableDirectBuffer.putBytes(dataLimit, payloadData, dataLength);
+        dataLimit += dataLength;
     }
 
     private void ensureDataCapacity(final int additionalCapacity)

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/PayloadFragmenter.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/PayloadFragmenter.java
@@ -84,7 +84,7 @@ public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame>
 
     public boolean hasNext()
     {
-        return dataOffset < data.capacity() || metadataOffset < metadata.remaining();
+        return dataOffset < data.remaining() || metadataOffset < metadata.remaining();
     }
 
     public Frame next()

--- a/reactivesocket-core/src/test/java/io/reactivesocket/FrameTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/FrameTest.java
@@ -219,7 +219,7 @@ public class FrameTest
         assertEquals("request data", TestUtil.byteToString(reusableFrame.getData()));
 
         final ByteBuffer metadataBuffer = reusableFrame.getMetadata();
-        assertEquals(0, metadataBuffer.capacity());
+        assertEquals(0, metadataBuffer.remaining());
         assertEquals(FrameType.REQUEST_RESPONSE, reusableFrame.getType());
         assertEquals(1, reusableFrame.getStreamId());
     }
@@ -238,7 +238,7 @@ public class FrameTest
         assertEquals("request data", TestUtil.byteToString(reusableFrame.getData()));
 
         final ByteBuffer metadataBuffer = reusableFrame.getMetadata();
-        assertEquals(0, metadataBuffer.capacity());
+        assertEquals(0, metadataBuffer.remaining());
         assertEquals(FrameType.FIRE_AND_FORGET, reusableFrame.getType());
         assertEquals(1, reusableFrame.getStreamId());
     }
@@ -257,7 +257,7 @@ public class FrameTest
         assertEquals("request data", TestUtil.byteToString(reusableFrame.getData()));
 
         final ByteBuffer metadataBuffer = reusableFrame.getMetadata();
-        assertEquals(0, metadataBuffer.capacity());
+        assertEquals(0, metadataBuffer.remaining());
         assertEquals(FrameType.REQUEST_STREAM, reusableFrame.getType());
         assertEquals(1, reusableFrame.getStreamId());
         assertEquals(128, Frame.Request.initialRequestN(reusableFrame));
@@ -277,7 +277,7 @@ public class FrameTest
         assertEquals("request data", TestUtil.byteToString(reusableFrame.getData()));
 
         final ByteBuffer metadataBuffer = reusableFrame.getMetadata();
-        assertEquals(0, metadataBuffer.capacity());
+        assertEquals(0, metadataBuffer.remaining());
         assertEquals(FrameType.REQUEST_SUBSCRIPTION, reusableFrame.getType());
         assertEquals(1, reusableFrame.getStreamId());
         assertEquals(128, Frame.Request.initialRequestN(reusableFrame));
@@ -297,7 +297,7 @@ public class FrameTest
         assertEquals("response data", TestUtil.byteToString(reusableFrame.getData()));
 
         final ByteBuffer metadataBuffer = reusableFrame.getMetadata();
-        assertEquals(0, metadataBuffer.capacity());
+        assertEquals(0, metadataBuffer.remaining());
         assertEquals(FrameType.NEXT, reusableFrame.getType());
         assertEquals(1, reusableFrame.getStreamId());
     }


### PR DESCRIPTION
Replace use of capacity which is only appropriate if you know exactly what the client has given you (a whole ByteBuffer representing the relevant data).  Uses remaining instead which assumes you trust your caller has given you a buffer that won't be change during the method call, but uses position and limit to support sliced buffers.