### PR TITLE
Generics correctness in `ClientBuilder`

### DIFF
--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/ClientBuilder.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/ClientBuilder.java
@@ -1,17 +1,14 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
  */
 package io.reactivesocket.client;
 
@@ -39,14 +36,14 @@ public class ClientBuilder<T> {
 
     private final ReactiveSocketConnector<T> connector;
 
-    private final Publisher<Collection<T>> source;
+    private final Publisher<? extends Collection<T>> source;
 
     private ClientBuilder(
         ScheduledExecutorService executor,
         long requestTimeout, TimeUnit requestTimeoutUnit,
         long connectTimeout, TimeUnit connectTimeoutUnit,
         ReactiveSocketConnector<T> connector,
-        Publisher<Collection<T>> source
+        Publisher<? extends Collection<T>> source
     ) {
         this.executor = executor;
         this.requestTimeout = requestTimeout;
@@ -97,7 +94,7 @@ public class ClientBuilder<T> {
         );
     }
 
-    public ClientBuilder<T> withSource(Publisher<Collection<T>> source) {
+    public ClientBuilder<T> withSource(Publisher<? extends Collection<T>> source) {
         return new ClientBuilder<>(
             executor,
             requestTimeout, requestTimeoutUnit,
@@ -193,8 +190,8 @@ public class ClientBuilder<T> {
         return "ClientBuilder("
             + "source=" + source
             + ", connector=" + connector
-            + ", requestTimeout=" + requestTimeout + " " + requestTimeoutUnit
-            + ", connectTimeout=" + connectTimeout + " " + connectTimeoutUnit
-            + ")";
+            + ", requestTimeout=" + requestTimeout + ' ' + requestTimeoutUnit
+            + ", connectTimeout=" + connectTimeout + ' ' + connectTimeoutUnit
+            + ')';
     }
 }

--- a/reactivesocket-discovery-eureka/src/main/java/io/reactivesocket/discovery/eureka/Eureka.java
+++ b/reactivesocket-discovery-eureka/src/main/java/io/reactivesocket/discovery/eureka/Eureka.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivesocket.discovery.eureka;
 
 import com.netflix.appinfo.InstanceInfo;
@@ -9,6 +22,7 @@ import org.reactivestreams.Subscriber;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,10 +33,10 @@ public class Eureka {
         this.client = client;
     }
 
-    public Publisher<List<SocketAddress>> subscribeToAsg(String vip, boolean secure) {
-        return new Publisher<List<SocketAddress>>() {
+    public Publisher<Collection<SocketAddress>> subscribeToAsg(String vip, boolean secure) {
+        return new Publisher<Collection<SocketAddress>>() {
             @Override
-            public void subscribe(Subscriber<? super List<SocketAddress>> subscriber) {
+            public void subscribe(Subscriber<? super Collection<SocketAddress>> subscriber) {
                 // TODO: backpressure
                 subscriber.onSubscribe(EmptySubscription.INSTANCE);
                 pushChanges(subscriber);


### PR DESCRIPTION
#### Problem

`ClientBuilder.withSource()` takes an argument of `Publisher<Collection<T>>` which means it doesn't accept an `Publisher<List<T>>`.
`Eureka` is providing `Publisher<List<T>>` so it is incompatible with `ClientBuilder`

#### Modification

Changed `ClientBuilder.withSource()` to take `Publisher<? extends Collection<T>>`.
Also changed `Eureka` to return `Publisher<Collection<T>>` which is the correct thing to do as returning a `List` doesn't really make a difference.