### PR TITLE
=build #138 Depend on the right RS version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
     }
 
     dependencies {
-        compile 'org.reactivestreams:reactive-streams:1.0.0.final'
+        compile 'org.reactivestreams:reactive-streams:1.0.0'
         compile 'org.agrona:Agrona:0.4.13'
         compile 'io.reactivex:rxjava:latest.release'
         compile 'io.reactivex:rxjava-reactive-streams:latest.release'


### PR DESCRIPTION
See more details explained in https://github.com/ReactiveSocket/reactivesocket-java/issues/138
I can elaborate on the complete story if you're keen on getting the whole story, however in general the simple rule is "ignore 1.0.0.final exists" :)