### PR TITLE
Fixes issue #128 (Close on `DuplexConnection`)

### DIFF
--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/BackupRequestSocket.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/BackupRequestSocket.java
@@ -108,23 +108,18 @@ public class BackupRequestSocket implements ReactiveSocket {
     }
 
     @Override
-    public void onShutdown(Completable c) {
-        child.onShutdown(c);
-    }
-
-    @Override
     public void sendLease(int ttl, int numberOfRequests) {
         child.sendLease(ttl, numberOfRequests);
     }
 
     @Override
-    public void shutdown() {
-        child.shutdown();
+    public Publisher<Void> close() {
+        return child.close();
     }
 
     @Override
-    public void close() throws Exception {
-        child.close();
+    public Publisher<Void> onClose() {
+        return child.onClose();
     }
 
     @Override

--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/DrainingSocket.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/DrainingSocket.java
@@ -17,6 +17,7 @@ package io.reactivesocket.client.filter;
 
 import io.reactivesocket.Payload;
 import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.internal.Publishers;
 import io.reactivesocket.rx.Completable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -129,29 +130,25 @@ public class DrainingSocket implements ReactiveSocket {
     }
 
     @Override
-    public void onShutdown(Completable c) {
-        child.onShutdown(c);
-    }
-
-    @Override
     public void sendLease(int ttl, int numberOfRequests) {
         child.sendLease(ttl, numberOfRequests);
     }
 
     @Override
-    public void shutdown() {
-        closed = true;
-        if (count.get() == 0) {
-            child.shutdown();
-        }
+    public Publisher<Void> close(){
+        return s -> {
+            closed = true;
+            if (count.get() == 0) {
+                child.close().subscribe(s);
+            } else {
+                onClose().subscribe(s);
+            }
+        };
     }
 
     @Override
-    public void close() throws Exception {
-        closed = true;
-        if (count.get() == 0) {
-            child.close();
-        }
+    public Publisher<Void> onClose() {
+        return child.onClose();
     }
 
     private void incr() {
@@ -161,11 +158,7 @@ public class DrainingSocket implements ReactiveSocket {
     private void decr() {
         int n = count.decrementAndGet();
         if (closed && n == 0) {
-            try {
-                child.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            Publishers.afterTerminate(child.close(), () -> {});
         }
     }
 

--- a/reactivesocket-client/src/test/java/io/reactivesocket/client/TestingReactiveSocket.java
+++ b/reactivesocket-client/src/test/java/io/reactivesocket/client/TestingReactiveSocket.java
@@ -2,6 +2,7 @@ package io.reactivesocket.client;
 
 import io.reactivesocket.Payload;
 import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.internal.EmptySubject;
 import io.reactivesocket.internal.rx.EmptySubscription;
 import io.reactivesocket.rx.Completable;
 import org.reactivestreams.Publisher;
@@ -16,6 +17,7 @@ import java.util.function.Function;
 public class TestingReactiveSocket implements ReactiveSocket {
 
     private final AtomicInteger count;
+    private final EmptySubject closeSubject = new EmptySubject();
     private final BiFunction<Subscriber<? super Payload>, Payload, Boolean> eachPayloadHandler;
 
     public TestingReactiveSocket(Function<Payload, Payload> responder) {
@@ -128,16 +130,20 @@ public class TestingReactiveSocket implements ReactiveSocket {
     }
 
     @Override
-    public void onShutdown(Completable c) {}
-
-    @Override
     public void sendLease(int ttl, int numberOfRequests) {
         throw new RuntimeException("Not Implemented");
     }
 
     @Override
-    public void shutdown() {}
+    public Publisher<Void> close() {
+        return s -> {
+            closeSubject.onComplete();
+            closeSubject.subscribe(s);
+        };
+    }
 
     @Override
-    public void close() throws Exception {}
+    public Publisher<Void> onClose() {
+        return closeSubject;
+    }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/DefaultReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/DefaultReactiveSocket.java
@@ -26,10 +26,7 @@ import io.reactivesocket.rx.Observable;
 import io.reactivesocket.rx.Observer;
 import org.agrona.BitUtil;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -374,8 +371,8 @@ public class DefaultReactiveSocket implements ReactiveSocket {
         }
 
         @Override
-        public Publisher<Void> closeNotifier() {
-            return connection.closeNotifier();
+        public Publisher<Void> onClose() {
+            return connection.onClose();
         }
 
         @Override
@@ -467,7 +464,7 @@ public class DefaultReactiveSocket implements ReactiveSocket {
 
     @Override
     public Publisher<Void> onClose() {
-        return connection.closeNotifier();
+        return connection.onClose();
     }
 
     public String toString() {

--- a/reactivesocket-core/src/main/java/io/reactivesocket/DuplexConnection.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/DuplexConnection.java
@@ -56,5 +56,5 @@ public interface DuplexConnection {
      *
      * @return A {@code Publisher} that completes when this {@code DuplexConnection} close is complete.
      */
-    Publisher<Void> closeNotifier();
+    Publisher<Void> onClose();
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/DuplexConnection.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/DuplexConnection.java
@@ -22,7 +22,7 @@ import java.io.Closeable;
 /**
  * Represents a connection with input/output that the protocol uses. 
  */
-public interface DuplexConnection extends Closeable {
+public interface DuplexConnection {
 
     Observable<Frame> getInput();
 
@@ -41,4 +41,20 @@ public interface DuplexConnection extends Closeable {
      * (higher is better).
      */
     double availability();
+
+    /**
+     * Close this {@code DuplexConnection} upon subscribing to the returned {@code Publisher}
+     *
+     * <em>This method is idempotent and hence can be called as many times at any point with same outcome.</em>
+     *
+     * @return A {@code Publisher} that completes when this {@code DuplexConnection} close is complete.
+     */
+    Publisher<Void> close();
+
+    /**
+     * Returns a {@code Publisher} that completes when this {@code DuplexConnection} is closed.
+     *
+     * @return A {@code Publisher} that completes when this {@code DuplexConnection} close is complete.
+     */
+    Publisher<Void> closeNotifier();
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/ReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ReactiveSocket.java
@@ -25,7 +25,7 @@ import java.util.function.Consumer;
 /**
  * Interface for a connection that supports sending requests and receiving responses
  */
-public interface ReactiveSocket extends AutoCloseable {
+public interface ReactiveSocket {
     Publisher<Void> fireAndForget(final Payload payload);
 
     Publisher<Payload> requestResponse(final Payload payload);
@@ -44,6 +44,23 @@ public interface ReactiveSocket extends AutoCloseable {
      * @return 0.0 to 1.0 indicating availability of sending requests
      */
     double availability();
+
+    /**
+     * Close this {@code ReactiveSocket} upon subscribing to the returned {@code Publisher}
+     *
+     * <em>This method is idempotent and hence can be called as many times at any point with same outcome.</em>
+     *
+     * @return A {@code Publisher} that completes when this {@code ReactiveSocket} close is complete.
+     */
+    Publisher<Void> close();
+
+    /**
+     * Returns a {@code Publisher} that completes when this {@code ReactiveSocket} is closed. A {@code ReactiveSocket}
+     * can be closed by explicitly calling {@link #close()} or when the underlying transport connection is closed.
+     *
+     * @return A {@code Publisher} that completes when this {@code ReactiveSocket} close is complete.
+     */
+    Publisher<Void> onClose();
 
     /**
      * Start protocol processing on the given DuplexConnection.
@@ -95,11 +112,6 @@ public interface ReactiveSocket extends AutoCloseable {
     void onRequestReady(Completable c);
 
     /**
-     * Registers a completable to be run when an ReactiveSocket is closed
-     */
-    void onShutdown(Completable c);
-
-    /**
      * Server granting new lease information to client
      *
      * Initial lease semantics are that server waits for periodic granting of leases by server side.
@@ -108,6 +120,4 @@ public interface ReactiveSocket extends AutoCloseable {
      * @param numberOfRequests
      */
     void sendLease(int ttl, int numberOfRequests);
-
-    void shutdown();
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/EmptySubject.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/EmptySubject.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.internal;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@code Publisher<Void>} implementation that can only send a termination signal.
+ */
+public class EmptySubject implements Publisher<Void> {
+
+    private static final Logger logger = LoggerFactory.getLogger(EmptySubject.class);
+
+    private boolean terminated;
+    private Throwable optionalError;
+    private final List<Subscriber<? super Void>> earlySubscribers = new ArrayList<>();
+
+    @Override
+    public void subscribe(Subscriber<? super Void> subscriber) {
+        boolean _completed = false;
+        final Throwable _error;
+        synchronized (this) {
+            if (terminated) {
+                _completed = true;
+            } else {
+                earlySubscribers.add(subscriber);
+            }
+            _error = optionalError;
+        }
+
+        if (_completed) {
+            if (_error != null) {
+                subscriber.onError(_error);
+            } else {
+                subscriber.onComplete();
+            }
+        }
+    }
+
+    public void onComplete() {
+        sendSignalIfRequired(null);
+    }
+
+    public void onError(Throwable throwable) {
+        sendSignalIfRequired(throwable);
+    }
+
+    private void sendSignalIfRequired(Throwable optionalError) {
+        List<Subscriber<? super Void>> subs = Collections.emptyList();
+        synchronized (this) {
+            if (!terminated) {
+                terminated = true;
+                subs = new ArrayList<>(earlySubscribers);
+                earlySubscribers.clear();
+                this.optionalError = optionalError;
+            }
+        }
+
+        for (Subscriber<? super Void> sub : subs) {
+            try {
+                if (optionalError != null) {
+                    sub.onError(optionalError);
+                } else {
+                    sub.onComplete();
+                }
+            } catch (Throwable e) {
+                logger.error("Error while sending terminal notification. Ignoring the error.", e);
+            }
+        }
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
@@ -1026,11 +1026,7 @@ public class Requester {
                 if (!connectionSubscription.compareAndSet(null, CANCELLED)) {
                     // cancel the one that was there if we failed to set the sentinel
                     connectionSubscription.get().dispose();
-                    try {
-                        connection.close();
-                    } catch (IOException e) {
-                        errorStream.accept(e);
-                    }
+                    connection.close();
                 }
             }
         });

--- a/reactivesocket-core/src/main/java/io/reactivesocket/util/ReactiveSocketProxy.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/util/ReactiveSocketProxy.java
@@ -121,27 +121,22 @@ public class ReactiveSocketProxy implements ReactiveSocket {
     }
 
     @Override
-    public void onShutdown(Completable c) {
-        child.onShutdown(c);
-    }
-
-    @Override
     public void sendLease(int ttl, int numberOfRequests) {
         child.sendLease(ttl, numberOfRequests);
     }
 
     @Override
-    public void shutdown() {
-        child.shutdown();
+    public Publisher<Void> close() {
+        return child.close();
     }
 
     @Override
-    public void close() throws Exception {
-        child.close();
+    public Publisher<Void> onClose() {
+        return child.onClose();
     }
 
     @Override
     public String toString() {
-        return "ReactiveSocketProxy(" + child + ")";
+        return "ReactiveSocketProxy(" + child + ')';
     }
 }

--- a/reactivesocket-core/src/perf/java/io/reactivesocket/perfutil/PerfTestConnection.java
+++ b/reactivesocket-core/src/perf/java/io/reactivesocket/perfutil/PerfTestConnection.java
@@ -15,21 +15,20 @@
  */
 package io.reactivesocket.perfutil;
 
-import java.io.IOException;
-
+import io.reactivesocket.DuplexConnection;
+import io.reactivesocket.Frame;
+import io.reactivesocket.internal.EmptySubject;
+import io.reactivesocket.rx.Completable;
+import io.reactivesocket.rx.Observable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-
-import io.reactivesocket.DuplexConnection;
-import io.reactivesocket.Frame;
-import io.reactivesocket.rx.Completable;
-import io.reactivesocket.rx.Observable;
 
 public class PerfTestConnection implements DuplexConnection {
 
 	public final PerfUnicastSubjectNoBackpressure<Frame> toInput = PerfUnicastSubjectNoBackpressure.create();
 	private PerfUnicastSubjectNoBackpressure<Frame> writeSubject = PerfUnicastSubjectNoBackpressure.create();
+	private final EmptySubject closeSubject = new EmptySubject();
 
 	@Override
 	public void addOutput(Publisher<Frame> o, Completable callback) {
@@ -80,6 +79,15 @@ public class PerfTestConnection implements DuplexConnection {
 	}
 
 	@Override
-	public void close() throws IOException {
+	public Publisher<Void> close() {
+		return s -> {
+			closeSubject.onComplete();
+			closeSubject.subscribe(s);
+		};
+	}
+
+	@Override
+	public Publisher<Void> closeNotifier() {
+		return closeSubject;
 	}
 }

--- a/reactivesocket-core/src/perf/java/io/reactivesocket/perfutil/PerfTestConnection.java
+++ b/reactivesocket-core/src/perf/java/io/reactivesocket/perfutil/PerfTestConnection.java
@@ -87,7 +87,7 @@ public class PerfTestConnection implements DuplexConnection {
 	}
 
 	@Override
-	public Publisher<Void> closeNotifier() {
+	public Publisher<Void> onClose() {
 		return closeSubject;
 	}
 }

--- a/reactivesocket-core/src/test/java/io/reactivesocket/LeaseTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/LeaseTest.java
@@ -15,6 +15,7 @@
  */
 package io.reactivesocket;
 
+import io.reactivesocket.internal.Publishers;
 import io.reactivesocket.internal.Responder;
 import org.junit.After;
 import org.junit.Before;
@@ -143,8 +144,8 @@ public class LeaseTest {
 
     @After
     public void shutdown() {
-        socketServer.shutdown();
-        socketClient.shutdown();
+        Publishers.afterTerminate(socketServer.close(), () -> {});
+        Publishers.afterTerminate(socketClient.close(), () -> {});
     }
 
     @Test(timeout=2000)

--- a/reactivesocket-core/src/test/java/io/reactivesocket/TestConnection.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/TestConnection.java
@@ -116,7 +116,7 @@ public class TestConnection implements DuplexConnection {
 	}
 
 	@Override
-	public Publisher<Void> closeNotifier() {
+	public Publisher<Void> onClose() {
 		return closeSubject;
 	}
 

--- a/reactivesocket-core/src/test/java/io/reactivesocket/TestFlowControlRequestN.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/TestFlowControlRequestN.java
@@ -15,6 +15,7 @@
  */
 package io.reactivesocket;
 
+import io.reactivesocket.internal.Publishers;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -457,7 +458,7 @@ public class TestFlowControlRequestN {
 
 	@AfterClass
 	public static void shutdown() {
-		socketServer.shutdown();
-		socketClient.shutdown();
+		Publishers.afterTerminate(socketServer.close(), () -> {});
+		Publishers.afterTerminate(socketClient.close(), () -> {});
 	}
 }

--- a/reactivesocket-core/src/test/java/io/reactivesocket/TestTransportRequestN.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/TestTransportRequestN.java
@@ -15,6 +15,7 @@
  */
 package io.reactivesocket;
 
+import io.reactivesocket.internal.Publishers;
 import io.reactivesocket.lease.FairLeaseGovernor;
 import io.reactivex.subscribers.TestSubscriber;
 import org.junit.After;
@@ -230,14 +231,10 @@ public class TestTransportRequestN {
 
 	@After
 	public void shutdown() {
-		socketServer.shutdown();
-		socketClient.shutdown();
-		try {
-			clientConnection.close();
-			serverConnection.close();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		Publishers.afterTerminate(socketServer.close(), () -> {});
+		Publishers.afterTerminate(socketClient.close(), () -> {});
+		Publishers.afterTerminate(clientConnection.close(), () -> {});
+		Publishers.afterTerminate(serverConnection.close(), () -> {});
 	}
 
 }

--- a/reactivesocket-core/src/test/java/io/reactivesocket/internal/EmptySubjectTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/internal/EmptySubjectTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.internal;
+
+import io.reactivex.subscribers.TestSubscriber;
+import org.junit.Test;
+
+public class EmptySubjectTest {
+
+    @Test(timeout = 10000)
+    public void testOnComplete() throws Exception {
+        EmptySubject subject = new EmptySubject();
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        subject.subscribe(subscriber);
+
+        subscriber.assertNotTerminated();
+        subject.onComplete();
+
+        subscriber.assertComplete();
+        subscriber.assertNoErrors();
+    }
+
+    @Test(timeout = 10000)
+    public void testOnError() throws Exception {
+        EmptySubject subject = new EmptySubject();
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        subject.subscribe(subscriber);
+
+        subscriber.assertNotTerminated();
+        subject.onError(new NullPointerException());
+
+        subscriber.assertNotComplete();
+        subscriber.assertError(NullPointerException.class);
+    }
+
+    @Test(timeout = 10000)
+    public void testOnErrorBeforeSubscribe() throws Exception {
+        EmptySubject subject = new EmptySubject();
+        subject.onError(new NullPointerException());
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        subject.subscribe(subscriber);
+        subscriber.assertNotComplete();
+        subscriber.assertError(NullPointerException.class);
+    }
+
+    @Test(timeout = 10000)
+    public void testCompleteBeforeSubscribe() throws Exception {
+        EmptySubject subject = new EmptySubject();
+        subject.onComplete();
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        subject.subscribe(subscriber);
+        subscriber.assertComplete();
+        subscriber.assertNoErrors();
+    }
+}

--- a/reactivesocket-stats-servo/src/main/java/io/reactivesocket/loadbalancer/servo/AvailabilityMetricReactiveSocket.java
+++ b/reactivesocket-stats-servo/src/main/java/io/reactivesocket/loadbalancer/servo/AvailabilityMetricReactiveSocket.java
@@ -99,17 +99,12 @@ public class AvailabilityMetricReactiveSocket implements ReactiveSocket {
     }
 
     @Override
-    public void shutdown() {
-        child.shutdown();
+    public Publisher<Void> close() {
+        return child.close();
     }
 
     @Override
-    public void close() throws Exception {
-        child.close();
-    }
-
-    @Override
-    public void onShutdown(Completable c) {
-        child.onShutdown(c);
+    public Publisher<Void> onClose() {
+        return child.onClose();
     }
 }

--- a/reactivesocket-stats-servo/src/test/java/io/reactivesocket/loadbalancer/servo/ServoMetricsReactiveSocketTest.java
+++ b/reactivesocket-stats-servo/src/test/java/io/reactivesocket/loadbalancer/servo/ServoMetricsReactiveSocketTest.java
@@ -17,6 +17,7 @@ package io.reactivesocket.loadbalancer.servo;
 
 import io.reactivesocket.Payload;
 import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.internal.Publishers;
 import io.reactivesocket.internal.rx.EmptySubscription;
 import io.reactivesocket.rx.Completable;
 import org.junit.Assert;
@@ -87,7 +88,15 @@ public class ServoMetricsReactiveSocketTest {
             }
 
             @Override
-            public void close() throws Exception {}
+            public Publisher<Void> close() {
+                return Publishers.empty();
+            }
+
+            @Override
+            public Publisher<Void> onClose() {
+                return Publishers.empty();
+            }
+
             @Override
             public void start(Completable completable) {}
             @Override
@@ -95,11 +104,7 @@ public class ServoMetricsReactiveSocketTest {
             @Override
             public void onRequestReady(Completable completable) {}
             @Override
-            public void onShutdown(Completable completable) {}
-            @Override
             public void sendLease(int i, int i1) {}
-            @Override
-            public void shutdown() {}
         }, "test");
 
         Publisher<Payload> payloadPublisher = client.requestResponse(new Payload() {
@@ -167,7 +172,15 @@ public class ServoMetricsReactiveSocketTest {
             }
 
             @Override
-            public void close() throws Exception {}
+            public Publisher<Void> close() {
+                return Publishers.empty();
+            }
+
+            @Override
+            public Publisher<Void> onClose() {
+                return Publishers.empty();
+            }
+
             @Override
             public void start(Completable completable) {}
             @Override
@@ -175,11 +188,7 @@ public class ServoMetricsReactiveSocketTest {
             @Override
             public void onRequestReady(Completable completable) {}
             @Override
-            public void onShutdown(Completable completable) {}
-            @Override
             public void sendLease(int i, int i1) {}
-            @Override
-            public void shutdown() {}
         }, "test");
 
         Publisher<Payload> payloadPublisher = client.requestResponse(new Payload() {
@@ -262,7 +271,15 @@ public class ServoMetricsReactiveSocketTest {
             }
 
             @Override
-            public void close() throws Exception {}
+            public Publisher<Void> close() {
+                return Publishers.empty();
+            }
+
+            @Override
+            public Publisher<Void> onClose() {
+                return Publishers.empty();
+            }
+
             @Override
             public void start(Completable completable) {}
             @Override
@@ -270,11 +287,7 @@ public class ServoMetricsReactiveSocketTest {
             @Override
             public void onRequestReady(Completable completable) {}
             @Override
-            public void onShutdown(Completable completable) {}
-            @Override
             public void sendLease(int i, int i1) {}
-            @Override
-            public void shutdown() {}
         }, "test");
 
         for (int i = 0; i < 10; i ++) {

--- a/reactivesocket-transport-aeron/src/main/java/io/reactivesocket/aeron/client/AeronClientDuplexConnection.java
+++ b/reactivesocket-transport-aeron/src/main/java/io/reactivesocket/aeron/client/AeronClientDuplexConnection.java
@@ -129,7 +129,7 @@ public class AeronClientDuplexConnection implements DuplexConnection, Loggable {
     }
 
     @Override
-    public Publisher<Void> closeNotifier() {
+    public Publisher<Void> onClose() {
         return closeSubject;
     }
 

--- a/reactivesocket-transport-aeron/src/main/java/io/reactivesocket/aeron/client/AeronClientDuplexConnectionFactory.java
+++ b/reactivesocket-transport-aeron/src/main/java/io/reactivesocket/aeron/client/AeronClientDuplexConnectionFactory.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import static io.reactivesocket.aeron.internal.Constants.SERVER_STREAM_ID;
 
@@ -214,7 +213,7 @@ public final class AeronClientDuplexConnectionFactory implements Loggable {
                         final Publication publication = establishConnectionHolder.getPublication();
                         AeronClientDuplexConnection aeronClientDuplexConnection
                             = new AeronClientDuplexConnection(publication, frameSendQueue);
-                        Publishers.afterTerminate(aeronClientDuplexConnection.closeNotifier(), () -> {
+                        Publishers.afterTerminate(aeronClientDuplexConnection.onClose(), () -> {
                             connections.remove(publication.sessionId());
 
                             // Send a message to the server that the connection is closed and that it needs to clean-up resources on it's side

--- a/reactivesocket-transport-aeron/src/main/java/io/reactivesocket/aeron/server/AeronServerDuplexConnection.java
+++ b/reactivesocket-transport-aeron/src/main/java/io/reactivesocket/aeron/server/AeronServerDuplexConnection.java
@@ -120,7 +120,7 @@ public class AeronServerDuplexConnection implements DuplexConnection, Loggable {
     }
 
     @Override
-    public Publisher<Void> closeNotifier() {
+    public Publisher<Void> onClose() {
         return closeSubject;
     }
 

--- a/reactivesocket-transport-aeron/src/main/java/io/reactivesocket/aeron/server/AeronServerDuplexConnection.java
+++ b/reactivesocket-transport-aeron/src/main/java/io/reactivesocket/aeron/server/AeronServerDuplexConnection.java
@@ -23,6 +23,7 @@ import io.reactivesocket.aeron.internal.Constants;
 import io.reactivesocket.aeron.internal.Loggable;
 import io.reactivesocket.aeron.internal.MessageType;
 import io.reactivesocket.aeron.internal.NotConnectedException;
+import io.reactivesocket.internal.EmptySubject;
 import io.reactivesocket.rx.Completable;
 import io.reactivesocket.rx.Disposable;
 import io.reactivesocket.rx.Observable;
@@ -38,6 +39,7 @@ public class AeronServerDuplexConnection implements DuplexConnection, Loggable {
     private final Publication publication;
     private final CopyOnWriteArrayList<Observer<Frame>> subjects;
     private volatile boolean isClosed;
+    private final EmptySubject closeSubject = new EmptySubject();
 
     public AeronServerDuplexConnection(
         Publication publication) {
@@ -106,11 +108,20 @@ public class AeronServerDuplexConnection implements DuplexConnection, Loggable {
     }
 
     @Override
-    public void close() {
-        isClosed = true;
-        try {
-            publication.close();
-        } catch (Throwable t) {}
+    public Publisher<Void> close() {
+        return s -> {
+            if (!isClosed) {
+                isClosed = true;
+                publication.close();
+                closeSubject.onComplete();
+            }
+            closeSubject.subscribe(s);
+        };
+    }
+
+    @Override
+    public Publisher<Void> closeNotifier() {
+        return closeSubject;
     }
 
     public String toString() {

--- a/reactivesocket-transport-local/src/main/java/io/reactivesocket/local/LocalClientDuplexConnection.java
+++ b/reactivesocket-transport-local/src/main/java/io/reactivesocket/local/LocalClientDuplexConnection.java
@@ -101,7 +101,7 @@ class LocalClientDuplexConnection implements DuplexConnection {
     }
 
     @Override
-    public Publisher<Void> closeNotifier() {
+    public Publisher<Void> onClose() {
         return closeSubject;
     }
 }

--- a/reactivesocket-transport-local/src/main/java/io/reactivesocket/local/LocalClientDuplexConnection.java
+++ b/reactivesocket-transport-local/src/main/java/io/reactivesocket/local/LocalClientDuplexConnection.java
@@ -17,6 +17,7 @@ package io.reactivesocket.local;
 
 import io.reactivesocket.DuplexConnection;
 import io.reactivesocket.Frame;
+import io.reactivesocket.internal.EmptySubject;
 import io.reactivesocket.rx.Completable;
 import io.reactivesocket.rx.Observable;
 import io.reactivesocket.rx.Observer;
@@ -24,13 +25,13 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import java.io.IOException;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 class LocalClientDuplexConnection implements DuplexConnection {
     private final String name;
 
     private final CopyOnWriteArrayList<Observer<Frame>> subjects;
+    private final EmptySubject closeSubject = new EmptySubject();
 
     public LocalClientDuplexConnection(String name) {
         this.name = name;
@@ -90,10 +91,17 @@ class LocalClientDuplexConnection implements DuplexConnection {
     }
 
     @Override
-    public void close() throws IOException {
-        LocalReactiveSocketManager
-            .getInstance()
-            .removeClientConnection(name);
+    public Publisher<Void> close() {
+        return s -> {
+            LocalReactiveSocketManager
+                    .getInstance()
+                    .removeClientConnection(name);
+            closeSubject.subscribe(s);
+        };
+    }
 
+    @Override
+    public Publisher<Void> closeNotifier() {
+        return closeSubject;
     }
 }

--- a/reactivesocket-transport-local/src/main/java/io/reactivesocket/local/LocalServerDuplexConection.java
+++ b/reactivesocket-transport-local/src/main/java/io/reactivesocket/local/LocalServerDuplexConection.java
@@ -102,7 +102,7 @@ class LocalServerDuplexConection implements DuplexConnection {
     }
 
     @Override
-    public Publisher<Void> closeNotifier() {
+    public Publisher<Void> onClose() {
         return closeSubject;
     }
 }

--- a/reactivesocket-transport-local/src/main/java/io/reactivesocket/local/LocalServerDuplexConection.java
+++ b/reactivesocket-transport-local/src/main/java/io/reactivesocket/local/LocalServerDuplexConection.java
@@ -17,6 +17,7 @@ package io.reactivesocket.local;
 
 import io.reactivesocket.DuplexConnection;
 import io.reactivesocket.Frame;
+import io.reactivesocket.internal.EmptySubject;
 import io.reactivesocket.rx.Completable;
 import io.reactivesocket.rx.Observable;
 import io.reactivesocket.rx.Observer;
@@ -24,13 +25,13 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import java.io.IOException;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 class LocalServerDuplexConection implements DuplexConnection {
     private final String name;
 
     private final CopyOnWriteArrayList<Observer<Frame>> subjects;
+    private final EmptySubject closeSubject = new EmptySubject();
 
     public LocalServerDuplexConection(String name) {
         this.name = name;
@@ -90,10 +91,18 @@ class LocalServerDuplexConection implements DuplexConnection {
     }
 
     @Override
-    public void close() throws IOException {
-        LocalReactiveSocketManager
-            .getInstance()
-            .removeServerDuplexConnection(name);
+    public Publisher<Void> close() {
+        return s -> {
+            LocalReactiveSocketManager
+                    .getInstance()
+                    .removeServerDuplexConnection(name);
+            s.onComplete();
+            closeSubject.onComplete();
+        };
+    }
 
+    @Override
+    public Publisher<Void> closeNotifier() {
+        return closeSubject;
     }
 }

--- a/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/TcpDuplexConnection.java
+++ b/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/TcpDuplexConnection.java
@@ -29,9 +29,13 @@ public class TcpDuplexConnection implements DuplexConnection {
 
     private final Connection<Frame, Frame> connection;
     private final rx.Observable<Frame> input;
+    private final Publisher<Void> closeNotifier;
+    private final Publisher<Void> close;
 
     public TcpDuplexConnection(Connection<Frame, Frame> connection) {
         this.connection = connection;
+        closeNotifier = RxReactiveStreams.toPublisher(connection.closeListener());
+        close = RxReactiveStreams.toPublisher(connection.close());
         input = connection.getInput().publish().refCount();
     }
 
@@ -71,8 +75,13 @@ public class TcpDuplexConnection implements DuplexConnection {
     }
 
     @Override
-    public void close() throws IOException {
-        connection.closeNow();
+    public Publisher<Void> close() {
+        return close;
+    }
+
+    @Override
+    public Publisher<Void> closeNotifier() {
+        return closeNotifier;
     }
 
     public String toString() {

--- a/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/TcpDuplexConnection.java
+++ b/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/TcpDuplexConnection.java
@@ -80,7 +80,7 @@ public class TcpDuplexConnection implements DuplexConnection {
     }
 
     @Override
-    public Publisher<Void> closeNotifier() {
+    public Publisher<Void> onClose() {
         return closeNotifier;
     }
 

--- a/reactivesocket-transport-tcp/src/test/java/io/reactivesocket/transport/tcp/ClientServerTest.java
+++ b/reactivesocket-transport-tcp/src/test/java/io/reactivesocket/transport/tcp/ClientServerTest.java
@@ -21,33 +21,33 @@ public class ClientServerTest {
     @Rule
     public final ClientSetupRule setup = new TcpClientSetupRule();
 
-    @Test(timeout = 60000)
+    @Test(timeout = 10000)
     public void testRequestResponse1() {
         setup.testRequestResponseN(1);
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 10000)
     public void testRequestResponse10() {
         setup.testRequestResponseN(10);
     }
 
 
-    @Test(timeout = 60000)
+    @Test(timeout = 10000)
     public void testRequestResponse100() {
         setup.testRequestResponseN(100);
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 10000)
     public void testRequestResponse10_000() {
         setup.testRequestResponseN(10_000);
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 10000)
     public void testRequestStream() {
         setup.testRequestStream();
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 10000)
     public void testRequestSubscription() throws InterruptedException {
         setup.testRequestSubscription();
     }

--- a/reactivesocket-transport-websocket/src/main/java/io/reactivesocket/transport/websocket/client/ClientWebSocketDuplexConnection.java
+++ b/reactivesocket-transport-websocket/src/main/java/io/reactivesocket/transport/websocket/client/ClientWebSocketDuplexConnection.java
@@ -36,7 +36,6 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -177,13 +176,13 @@ public class ClientWebSocketDuplexConnection implements DuplexConnection {
                     }
                 });
             } else {
-                closeNotifier().subscribe(s);
+                onClose().subscribe(s);
             }
         };
     }
 
     @Override
-    public Publisher<Void> closeNotifier() {
+    public Publisher<Void> onClose() {
         return s -> {
             channel.closeFuture().addListener(new ChannelFutureListener() {
                 @Override

--- a/reactivesocket-transport-websocket/src/main/java/io/reactivesocket/transport/websocket/server/ServerWebSocketDuplexConnection.java
+++ b/reactivesocket-transport-websocket/src/main/java/io/reactivesocket/transport/websocket/server/ServerWebSocketDuplexConnection.java
@@ -113,13 +113,13 @@ public class ServerWebSocketDuplexConnection implements DuplexConnection {
                     }
                 });
             } else {
-                closeNotifier().subscribe(s);
+                onClose().subscribe(s);
             }
         };
     }
 
     @Override
-    public Publisher<Void> closeNotifier() {
+    public Publisher<Void> onClose() {
         return s -> {
             ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
                 @Override


### PR DESCRIPTION
#### Problem
As described in the issue #128, currently `ReactiveSocket` does not listen to `DuplexConnection` closures.

#### Modification

As suggested in the issue, removed `onShutdown()` and `shutdown()` methods, in favor of `close()` and `closeNotifier()` methods.
Added `close()` and `closeNotifier()` methods in `DuplexConnection`