### PR TITLE
`ClientBuilder.build` is now asynchronous.

### DIFF
--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/ClientBuilder.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/ClientBuilder.java
@@ -118,6 +118,10 @@ public class ClientBuilder<T> {
                         subscriber.onError(new IllegalStateException("Please configure the source!"));
                         return;
                     }
+                    if (executor == null) {
+                        subscriber.onError(new IllegalStateException("Please configure the executor!"));
+                        return;
+                    }
                     if (connector == null) {
                         subscriber.onError(new IllegalStateException("Please configure the connector!"));
                         return;

--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/ClientBuilder.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/ClientBuilder.java
@@ -23,7 +23,9 @@ import org.reactivestreams.Subscription;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ClientBuilder<T> {
     private final ScheduledExecutorService executor;
@@ -104,26 +106,55 @@ public class ClientBuilder<T> {
         );
     }
 
-    public ReactiveSocket build() {
-        if (source == null) {
-            throw new IllegalStateException("Please configure the source!");
-        }
-        if (connector == null) {
-            throw new IllegalStateException("Please configure the connector!");
-        }
+    public Publisher<ReactiveSocket> build() {
+        return subscriber -> {
+            subscriber.onSubscribe(new Subscription() {
+                private ScheduledFuture<?> scheduledFuture = null;
+                private AtomicBoolean cancelled = new AtomicBoolean(false);
 
+                @Override
+                public void request(long n) {
+                    if (source == null) {
+                        subscriber.onError(new IllegalStateException("Please configure the source!"));
+                        return;
+                    }
+                    if (connector == null) {
+                        subscriber.onError(new IllegalStateException("Please configure the connector!"));
+                        return;
+                    }
 
-        ReactiveSocketConnector<T> filterConnector = connector;
-        if (requestTimeout > 0) {
-            filterConnector = filterConnector
-                .chain(socket -> new TimeoutSocket(socket, requestTimeout, requestTimeoutUnit, executor));
-        }
-        filterConnector = filterConnector.chain(DrainingSocket::new);
+                    ReactiveSocketConnector<T> filterConnector = connector;
+                    if (requestTimeout > 0) {
+                        filterConnector = filterConnector
+                            .chain(socket -> new TimeoutSocket(socket, requestTimeout, requestTimeoutUnit, executor));
+                    }
+                    filterConnector = filterConnector.chain(DrainingSocket::new);
 
-        Publisher<? extends Collection<ReactiveSocketFactory<T>>> factories =
-            sourceToFactory(source, filterConnector);
+                    Publisher<? extends Collection<ReactiveSocketFactory<T>>> factories =
+                        sourceToFactory(source, filterConnector);
+                    LoadBalancer<T> loadBalancer = new LoadBalancer<>(factories);
 
-        return new LoadBalancer<>(factories);
+                    scheduledFuture = executor.scheduleAtFixedRate(() -> {
+                        if (loadBalancer.availability() > 0 && !cancelled.get()) {
+                            subscriber.onNext(loadBalancer);
+                            subscriber.onComplete();
+                            if (scheduledFuture != null) {
+                                scheduledFuture.cancel(true);
+                            }
+                        }
+                    }, 1L, 50L, TimeUnit.MILLISECONDS);
+                }
+
+                @Override
+                public void cancel() {
+                    if (cancelled.compareAndSet(false, true)) {
+                        if (scheduledFuture != null) {
+                            scheduledFuture.cancel(true);
+                        }
+                    }
+                }
+            });
+        };
     }
 
     private Publisher<? extends Collection<ReactiveSocketFactory<T>>> sourceToFactory(
@@ -136,8 +167,8 @@ public class ClientBuilder<T> {
 
                 @Override
                 public void onSubscribe(Subscription s) {
-                    subscriber.onSubscribe(s);
                     current = Collections.emptyMap();
+                    subscriber.onSubscribe(s);
                 }
 
                 @Override

--- a/reactivesocket-client/src/test/java/io/reactivesocket/client/ClientBuilderTest.java
+++ b/reactivesocket-client/src/test/java/io/reactivesocket/client/ClientBuilderTest.java
@@ -1,0 +1,100 @@
+package io.reactivesocket.client;
+
+import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.ReactiveSocketConnector;
+import io.reactivesocket.internal.Publishers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class ClientBuilderTest {
+
+    @Test(timeout = 10_000L)
+    public void testIllegalState() throws ExecutionException, InterruptedException {
+        // you need to specify the source and the connector
+        Publisher<ReactiveSocket> socketPublisher = ClientBuilder.instance().build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        socketPublisher.subscribe(new Subscriber<ReactiveSocket>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(1L);
+            }
+
+            @Override
+            public void onNext(ReactiveSocket reactiveSocket) {
+                throw new AssertionError("onNext invoked when not expected.");
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                MatcherAssert.assertThat("Unexpected exception in onError", t, instanceOf(IllegalStateException.class));
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                throw new AssertionError("onComplete invoked when not expected.");
+            }
+        });
+
+        latch.await();
+    }
+
+    @Test(timeout = 10_000L)
+    public void testReturnedRSisAvailable() throws ExecutionException, InterruptedException {
+
+        List<SocketAddress> addrs = Collections.singletonList(
+            InetSocketAddress.createUnresolved("localhost", 8080));
+        Publisher<List<SocketAddress>> src = Publishers.just(addrs);
+
+        ReactiveSocketConnector<SocketAddress> connector =
+            address -> Publishers.just(new TestingReactiveSocket(Function.identity()));
+
+        Publisher<ReactiveSocket> socketPublisher =
+            ClientBuilder.<SocketAddress>instance()
+                .withSource(src)
+                .withConnector(connector)
+                .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        socketPublisher.subscribe(new Subscriber<ReactiveSocket>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(1L);
+            }
+
+            @Override
+            public void onNext(ReactiveSocket reactiveSocket) {
+                // the returned ReactiveSocket must have an availability > 0.0
+                if (reactiveSocket.availability() == 0.0) {
+                    throw new AssertionError("Loadbalancer availability is zero!");
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                throw new AssertionError("onError invoked when not expected.");
+            }
+
+            @Override
+            public void onComplete() {
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+    }
+}

--- a/reactivesocket-examples/src/main/java/io/reactivesocket/examples/StressTest.java
+++ b/reactivesocket-examples/src/main/java/io/reactivesocket/examples/StressTest.java
@@ -116,14 +116,14 @@ public class StressTest {
 
         TcpReactiveSocketConnector tcp = TcpReactiveSocketConnector.create(setupPayload, Throwable::printStackTrace);
 
-        ReactiveSocket client = ClientBuilder.<SocketAddress>instance()
+        Publisher<ReactiveSocket> socketPublisher = ClientBuilder.<SocketAddress>instance()
             .withSource(getServersList())
             .withConnector(tcp)
             .withConnectTimeout(1, TimeUnit.SECONDS)
             .withRequestTimeout(1, TimeUnit.SECONDS)
             .build();
 
-        Unsafe.awaitAvailability(client);
+        ReactiveSocket client = Unsafe.blockingSingleWait(socketPublisher, 5, TimeUnit.SECONDS);
         System.out.println("Client ready, starting the load...");
 
         long testDurationNs = TimeUnit.NANOSECONDS.convert(60, TimeUnit.SECONDS);


### PR DESCRIPTION
***Problem***
The ClientBuilder `build` API return a ReactiveSocket.
This ReactiveSocket is returned while connections are still in establishing
mode, then it will fail until the connections established.
The current solution is to call `Unsafe.awaitAvailability` which is cluncky.

***Solution***
Create a more robust API that return a `Publisher<ReactiveSocket>`, it is now
obvious that the API is asynchronous.

***Modification***
I found a bug in `sourceToFactory`, where I was calling `subscriber.onSubscribe`
before initializing the `current` Map.