### PR TITLE
Remove `ReactiveSocketFactory.remote()`

### DIFF
--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/TimeoutFactory.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/TimeoutFactory.java
@@ -24,12 +24,12 @@ import org.reactivestreams.Publisher;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-public class TimeoutFactory<T> extends ReactiveSocketFactoryProxy<T> {
+public class TimeoutFactory extends ReactiveSocketFactoryProxy {
     private final Publisher<Void> timer;
     private final long timeout;
     private final TimeUnit unit;
 
-    public TimeoutFactory(ReactiveSocketFactory<T> child, long timeout, TimeUnit unit,
+    public TimeoutFactory(ReactiveSocketFactory child, long timeout, TimeUnit unit,
                           ScheduledExecutorService executor) {
         super(child);
         this.timeout = timeout;

--- a/reactivesocket-client/src/test/java/io/reactivesocket/client/FailureReactiveSocketTest.java
+++ b/reactivesocket-client/src/test/java/io/reactivesocket/client/FailureReactiveSocketTest.java
@@ -115,7 +115,7 @@ public class FailureReactiveSocketTest {
                 throw new RuntimeException();
             }
         });
-        ReactiveSocketFactory<String> factory = new ReactiveSocketFactory<String>() {
+        ReactiveSocketFactory factory = new ReactiveSocketFactory() {
             @Override
             public Publisher<ReactiveSocket> apply() {
                 return subscriber -> {
@@ -129,13 +129,9 @@ public class FailureReactiveSocketTest {
                 return 1.0;
             }
 
-            @Override
-            public String remote() {
-                return "Testing";
-            }
         };
 
-        FailureAwareFactory<String> failureFactory = new FailureAwareFactory<>(factory, 100, TimeUnit.MILLISECONDS);
+        FailureAwareFactory failureFactory = new FailureAwareFactory(factory, 100, TimeUnit.MILLISECONDS);
 
         CountDownLatch latch = new CountDownLatch(1);
         failureFactory.apply().subscribe(new Subscriber<ReactiveSocket>() {

--- a/reactivesocket-client/src/test/java/io/reactivesocket/client/LoadBalancerTest.java
+++ b/reactivesocket-client/src/test/java/io/reactivesocket/client/LoadBalancerTest.java
@@ -37,9 +37,9 @@ public class LoadBalancerTest {
         InetSocketAddress local1 = InetSocketAddress.createUnresolved("localhost", 7001);
 
         TestingReactiveSocket socket = new TestingReactiveSocket(Function.identity());
-        ReactiveSocketFactory<SocketAddress> failing = failingFactory(local0);
-        ReactiveSocketFactory<SocketAddress> succeeding = succeedingFactory(local1, socket);
-        List<ReactiveSocketFactory<?>> factories = Arrays.asList(failing, succeeding);
+        ReactiveSocketFactory failing = failingFactory(local0);
+        ReactiveSocketFactory succeeding = succeedingFactory(local1, socket);
+        List<ReactiveSocketFactory> factories = Arrays.asList(failing, succeeding);
 
         testBalancer(factories);
     }
@@ -62,15 +62,15 @@ public class LoadBalancerTest {
             }
         };
 
-        ReactiveSocketFactory<SocketAddress> failing = succeedingFactory(local0, failingSocket);
-        ReactiveSocketFactory<SocketAddress> succeeding = succeedingFactory(local1, socket);
-        List<ReactiveSocketFactory<?>> factories = Arrays.asList(failing, succeeding);
+        ReactiveSocketFactory failing = succeedingFactory(local0, failingSocket);
+        ReactiveSocketFactory succeeding = succeedingFactory(local1, socket);
+        List<ReactiveSocketFactory> factories = Arrays.asList(failing, succeeding);
 
         testBalancer(factories);
     }
 
-    private void testBalancer(List<ReactiveSocketFactory<?>> factories) throws InterruptedException {
-        Publisher<List<ReactiveSocketFactory<?>>> src = s -> {
+    private void testBalancer(List<ReactiveSocketFactory> factories) throws InterruptedException {
+        Publisher<List<ReactiveSocketFactory>> src = s -> {
             s.onNext(factories);
             s.onComplete();
         };
@@ -116,8 +116,8 @@ public class LoadBalancerTest {
         latch.await();
     }
 
-    private ReactiveSocketFactory<SocketAddress> succeedingFactory(SocketAddress sa, ReactiveSocket socket) {
-        return new ReactiveSocketFactory<SocketAddress>() {
+    private ReactiveSocketFactory succeedingFactory(SocketAddress sa, ReactiveSocket socket) {
+        return new ReactiveSocketFactory() {
             @Override
             public Publisher<ReactiveSocket> apply() {
                 return s -> s.onNext(socket);
@@ -128,15 +128,11 @@ public class LoadBalancerTest {
                 return 1.0;
             }
 
-            @Override
-            public SocketAddress remote() {
-                return sa;
-            }
         };
     }
 
-    private ReactiveSocketFactory<SocketAddress> failingFactory(SocketAddress sa) {
-        return new ReactiveSocketFactory<SocketAddress>() {
+    private ReactiveSocketFactory failingFactory(SocketAddress sa) {
+        return new ReactiveSocketFactory() {
             @Override
             public Publisher<ReactiveSocket> apply() {
                 Assert.assertTrue(false);
@@ -148,10 +144,6 @@ public class LoadBalancerTest {
                 return 0.0;
             }
 
-            @Override
-            public SocketAddress remote() {
-                return sa;
-            }
         };
     }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/ReactiveSocketConnector.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ReactiveSocketConnector.java
@@ -32,8 +32,8 @@ public interface ReactiveSocketConnector<T> {
      * @param address the address to connect the connector to
      * @return the factory
      */
-    default ReactiveSocketFactory<T> toFactory(T address) {
-        return new ReactiveSocketFactory<T>() {
+    default ReactiveSocketFactory toFactory(T address) {
+        return new ReactiveSocketFactory() {
             @Override
             public Publisher<ReactiveSocket> apply() {
                 return connect(address);
@@ -44,10 +44,6 @@ public interface ReactiveSocketConnector<T> {
                 return 1.0;
             }
 
-            @Override
-            public T remote() {
-                return address;
-            }
         };
     }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/ReactiveSocketFactory.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ReactiveSocketFactory.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
  * This abstraction is useful for abstracting the creation of a ReactiveSocket
  * (e.g. inside the LoadBalancer which create ReactiveSocket as needed)
  */
-public interface ReactiveSocketFactory<T> {
+public interface ReactiveSocketFactory {
 
     /**
      * Construct the ReactiveSocket.
@@ -39,13 +39,8 @@ public interface ReactiveSocketFactory<T> {
      */
     double availability();
 
-    /**
-     * @return an identifier of the remote location
-     */
-    T remote();
-
-    default ReactiveSocketFactory<T> chain(Function<Publisher<ReactiveSocket>, Publisher<ReactiveSocket>> conversion) {
-        return new ReactiveSocketFactoryProxy<T>(ReactiveSocketFactory.this) {
+    default ReactiveSocketFactory chain(Function<Publisher<ReactiveSocket>, Publisher<ReactiveSocket>> conversion) {
+        return new ReactiveSocketFactoryProxy(ReactiveSocketFactory.this) {
             @Override
             public Publisher<ReactiveSocket> apply() {
                 return conversion.apply(super.apply());

--- a/reactivesocket-core/src/main/java/io/reactivesocket/util/ReactiveSocketFactoryProxy.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/util/ReactiveSocketFactoryProxy.java
@@ -6,13 +6,11 @@ import org.reactivestreams.Publisher;
 
 /**
  * A simple implementation that just forwards all methods to a passed child {@code ReactiveSocketFactory}.
- *
- * @param <T> Type parameter for {@link ReactiveSocketFactory}
  */
-public abstract class ReactiveSocketFactoryProxy<T> implements ReactiveSocketFactory<T> {
-    protected final ReactiveSocketFactory<T> child;
+public abstract class ReactiveSocketFactoryProxy implements ReactiveSocketFactory {
+    protected final ReactiveSocketFactory child;
 
-    protected ReactiveSocketFactoryProxy(ReactiveSocketFactory<T> child) {
+    protected ReactiveSocketFactoryProxy(ReactiveSocketFactory child) {
         this.child = child;
     }
 
@@ -26,8 +24,4 @@ public abstract class ReactiveSocketFactoryProxy<T> implements ReactiveSocketFac
         return child.availability();
     }
 
-    @Override
-    public T remote() {
-        return child.remote();
-    }
 }


### PR DESCRIPTION
***Problem***
Since the refactoring of the `LoadBalancer` to use `List` instead of `Map`,
there's no need for a `remote` method that identify a remote server.
Furthermore, that's the only reason why LoadBalancer is generic.

***Solution***
Delete the method `ReactiveSocketFactory.remote()` as well as all the
references to it.