### PR TITLE
Properly propagate exceptions type from server client.

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/TransportException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/TransportException.java
@@ -24,5 +24,4 @@ public class TransportException extends Throwable {
     public synchronized Throwable fillInStackTrace() {
         return this;
     }
-
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/Requester.java
@@ -15,7 +15,6 @@
  */
 package io.reactivesocket.internal;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -837,9 +836,8 @@ public class Requester {
                 cancel();
             } else if (type == FrameType.ERROR) {
                 terminated.set(true);
-                final ByteBuffer byteBuffer = frame.getData();
-                String errorMessage = getByteBufferAsString(byteBuffer);
-                onError(new RuntimeException(errorMessage));
+                Throwable throwable = Exceptions.from(frame);
+                onError(throwable);
                 cancel();
             } else {
                 onError(new RuntimeException("Unexpected FrameType: " + frame.getType()));

--- a/reactivesocket-core/src/test/java/io/reactivesocket/LeaseTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/LeaseTest.java
@@ -15,6 +15,7 @@
  */
 package io.reactivesocket;
 
+import io.reactivesocket.exceptions.RejectedException;
 import io.reactivesocket.internal.Publishers;
 import io.reactivesocket.internal.Responder;
 import org.junit.After;
@@ -182,7 +183,7 @@ public class LeaseTest {
         TestSubscriber<Payload> ts2 = new TestSubscriber<>();
         response2.subscribe(ts2);
         ts2.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts2.assertError(RuntimeException.class);
+        ts2.assertError(RejectedException.class);
     }
 
     @Test(timeout=2000)

--- a/reactivesocket-core/src/test/java/io/reactivesocket/internal/RequesterTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/internal/RequesterTest.java
@@ -21,6 +21,7 @@ import io.reactivesocket.FrameType;
 import io.reactivesocket.LatchedCompletable;
 import io.reactivesocket.Payload;
 import io.reactivesocket.TestConnection;
+import io.reactivesocket.exceptions.InvalidRequestException;
 import io.reactivesocket.util.PayloadImpl;
 import io.reactivex.Observable;
 import io.reactivex.subjects.ReplaySubject;
@@ -165,7 +166,7 @@ public class RequesterTest
 
         conn.toInput.send(Frame.Error.from(2, new RuntimeException("Failed")));
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertError(Exception.class);
+        ts.assertError(InvalidRequestException.class);
         assertEquals("Failed", ts.errors().get(0).getMessage());
     }
 
@@ -313,7 +314,7 @@ public class RequesterTest
         conn.toInput.send(utf8EncodedErrorFrame(2, "Failure"));
 
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertError(Exception.class);
+        ts.assertError(InvalidRequestException.class);
         ts.assertValue(utf8EncodedPayload("hello", null));
         assertEquals("Failure", ts.errors().get(0).getMessage());
     }


### PR DESCRIPTION
***Problem***
Errors generated from the `Responder` are serialized according to the spec
https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#error-codes
but the type is lost when deserialized by the `Requester`.

***Solution***
Instead of generating a RuntimeException containing the string of the error,
generate the right Exception type based on the error code.
This allows user code or filter to make smart decision based on the Exception
type (Retryable, ...)