### PR TITLE
Fix Error flags to match the spec + review the `frame` package.

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ByteBufferUtil.java
@@ -21,8 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ByteBufferUtil {
 
-    private ByteBufferUtil() {
-    }
+    private ByteBufferUtil() {}
 
     /**
      * Slice a portion of the {@link ByteBuffer} while preserving the buffers position and limit.

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ErrorFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ErrorFrameFlyweight.java
@@ -39,11 +39,11 @@ public class ErrorFrameFlyweight {
     public static final int INVALID_SETUP = 0x0001;
     public static final int UNSUPPORTED_SETUP = 0x0002;
     public static final int REJECTED_SETUP = 0x0003;
-    public static final int CONNECTION_ERROR = 0x0011;
-    public static final int APPLICATION_ERROR = 0x0021;
+    public static final int CONNECTION_ERROR = 0x0101;
+    public static final int APPLICATION_ERROR = 0x0201;
     public static final int REJECTED = 0x0022;
-    public static final int CANCEL = 0x0023;
-    public static final int INVALID = 0x0024;
+    public static final int CANCEL = 0x0203;
+    public static final int INVALID = 0x0204;
 
     // relative to start of passed offset
     private static final int ERROR_CODE_FIELD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/KeepaliveFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/KeepaliveFrameFlyweight.java
@@ -21,22 +21,20 @@ import org.agrona.MutableDirectBuffer;
 
 import java.nio.ByteBuffer;
 
-public class KeepaliveFrameFlyweight
-{
+public class KeepaliveFrameFlyweight {
     private KeepaliveFrameFlyweight() {}
 
     private static final int PAYLOAD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;
 
-    public static int computeFrameLength(final int dataLength)
-    {
+    public static int computeFrameLength(final int dataLength) {
         return FrameHeaderFlyweight.computeFrameHeaderLength(FrameType.SETUP, 0, dataLength);
     }
 
     public static int encode(
         final MutableDirectBuffer mutableDirectBuffer,
         final int offset,
-        final ByteBuffer data)
-    {
+        final ByteBuffer data
+    ) {
         final int frameLength = computeFrameLength(data.remaining());
 
         int length = FrameHeaderFlyweight.encodeFrameHeader(mutableDirectBuffer, offset, frameLength, 0, FrameType.KEEPALIVE, 0);
@@ -46,8 +44,7 @@ public class KeepaliveFrameFlyweight
         return length;
     }
 
-    public static int payloadOffset(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int payloadOffset(final DirectBuffer directBuffer, final int offset) {
         return offset + PAYLOAD_OFFSET;
     }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/LeaseFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/LeaseFrameFlyweight.java
@@ -23,8 +23,7 @@ import org.agrona.MutableDirectBuffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-public class LeaseFrameFlyweight
-{
+public class LeaseFrameFlyweight {
     private LeaseFrameFlyweight() {}
 
     // relative to start of passed offset
@@ -32,10 +31,8 @@ public class LeaseFrameFlyweight
     private static final int NUM_REQUESTS_FIELD_OFFSET = TTL_FIELD_OFFSET + BitUtil.SIZE_OF_INT;
     private static final int PAYLOAD_OFFSET = NUM_REQUESTS_FIELD_OFFSET + BitUtil.SIZE_OF_INT;
 
-    public static int computeFrameLength(final int metadataLength)
-    {
+    public static int computeFrameLength(final int metadataLength) {
         int length = FrameHeaderFlyweight.computeFrameHeaderLength(FrameType.SETUP, metadataLength, 0);
-
         return length + BitUtil.SIZE_OF_INT * 2;
     }
 
@@ -44,8 +41,8 @@ public class LeaseFrameFlyweight
         final int offset,
         final int ttl,
         final int numRequests,
-        final ByteBuffer metadata)
-    {
+        final ByteBuffer metadata
+    ) {
         final int frameLength = computeFrameLength(metadata.remaining());
 
         int length = FrameHeaderFlyweight.encodeFrameHeader(mutableDirectBuffer, offset, frameLength, 0, FrameType.LEASE, 0);
@@ -59,18 +56,15 @@ public class LeaseFrameFlyweight
         return length;
     }
 
-    public static int ttl(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int ttl(final DirectBuffer directBuffer, final int offset) {
         return directBuffer.getInt(offset + TTL_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
-    public static int numRequests(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int numRequests(final DirectBuffer directBuffer, final int offset) {
         return directBuffer.getInt(offset + NUM_REQUESTS_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
-    public static int payloadOffset(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int payloadOffset(final DirectBuffer directBuffer, final int offset) {
         return offset + PAYLOAD_OFFSET;
     }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/PayloadBuilder.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/PayloadBuilder.java
@@ -27,8 +27,7 @@ import java.util.Arrays;
 /**
  * Builder for appending buffers that grows dataCapacity as necessary. Similar to Aeron's PayloadBuilder.
  */
-public class PayloadBuilder
-{
+public class PayloadBuilder {
     public static final int INITIAL_CAPACITY = Math.max(Frame.DATA_MTU, Frame.METADATA_MTU);
 
     private final MutableDirectBuffer dataMutableDirectBuffer;
@@ -41,8 +40,7 @@ public class PayloadBuilder
     private int dataCapacity;
     private int metadataCapacity;
 
-    public PayloadBuilder()
-    {
+    public PayloadBuilder() {
         dataCapacity = BitUtil.findNextPositivePowerOfTwo(INITIAL_CAPACITY);
         metadataCapacity = BitUtil.findNextPositivePowerOfTwo(INITIAL_CAPACITY);
         dataBuffer = new byte[dataCapacity];
@@ -51,24 +49,20 @@ public class PayloadBuilder
         metadataMutableDirectBuffer = new UnsafeBuffer(metadataBuffer);
     }
 
-    public Payload payload()
-    {
-        return new Payload()
-        {
+    public Payload payload() {
+        return new Payload() {
             public ByteBuffer getData()
             {
                 return ByteBuffer.wrap(dataBuffer, 0, dataLimit);
             }
 
-            public ByteBuffer getMetadata()
-            {
+            public ByteBuffer getMetadata() {
                 return ByteBuffer.wrap(metadataBuffer, 0, metadataLimit);
             }
         };
     }
 
-    public void append(final Payload payload)
-    {
+    public void append(final Payload payload) {
         final ByteBuffer payloadMetadata = payload.getMetadata();
         final ByteBuffer payloadData = payload.getData();
         final int metadataLength = payloadMetadata.remaining();
@@ -83,18 +77,15 @@ public class PayloadBuilder
         dataLimit += dataLength;
     }
 
-    private void ensureDataCapacity(final int additionalCapacity)
-    {
+    private void ensureDataCapacity(final int additionalCapacity) {
         final int requiredCapacity = dataLimit + additionalCapacity;
 
-        if (requiredCapacity < 0)
-        {
+        if (requiredCapacity < 0) {
             final String s = String.format("Insufficient data capacity: dataLimit=%d additional=%d", dataLimit, additionalCapacity);
             throw new IllegalStateException(s);
         }
 
-        if (requiredCapacity > dataCapacity)
-        {
+        if (requiredCapacity > dataCapacity) {
             final int newCapacity = findSuitableCapacity(dataCapacity, requiredCapacity);
             final byte[] newBuffer = Arrays.copyOf(dataBuffer, newCapacity);
 
@@ -104,18 +95,15 @@ public class PayloadBuilder
         }
     }
 
-    private void ensureMetadataCapacity(final int additionalCapacity)
-    {
+    private void ensureMetadataCapacity(final int additionalCapacity) {
         final int requiredCapacity = metadataLimit + additionalCapacity;
 
-        if (requiredCapacity < 0)
-        {
+        if (requiredCapacity < 0) {
             final String s = String.format("Insufficient metadata capacity: metadataLimit=%d additional=%d", metadataLimit, additionalCapacity);
             throw new IllegalStateException(s);
         }
 
-        if (requiredCapacity > metadataCapacity)
-        {
+        if (requiredCapacity > metadataCapacity) {
             final int newCapacity = findSuitableCapacity(metadataCapacity, requiredCapacity);
             final byte[] newBuffer = Arrays.copyOf(metadataBuffer, newCapacity);
 
@@ -125,13 +113,10 @@ public class PayloadBuilder
         }
     }
 
-    private static int findSuitableCapacity(int capacity, final int requiredCapacity)
-    {
-        do
-        {
+    private static int findSuitableCapacity(int capacity, final int requiredCapacity) {
+        do {
             capacity <<= 1;
-        }
-        while (capacity < requiredCapacity);
+        } while (capacity < requiredCapacity);
 
         return capacity;
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/PayloadFragmenter.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/PayloadFragmenter.java
@@ -27,10 +27,8 @@ import java.util.Iterator;
  *
  * Not thread-safe
  */
-public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame>
-{
-    private enum Type
-    {
+public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame> {
+    private enum Type {
         RESPONSE, RESPONSE_COMPLETE, REQUEST_CHANNEL
     }
 
@@ -44,51 +42,43 @@ public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame>
     private int streamId;
     private int initialRequestN;
 
-    public PayloadFragmenter(final int metadataMtu, final int dataMtu)
-    {
+    public PayloadFragmenter(final int metadataMtu, final int dataMtu) {
         this.metadataMtu = metadataMtu;
         this.dataMtu = dataMtu;
     }
 
-    public void resetForResponse(final int streamId, final Payload payload)
-    {
+    public void resetForResponse(final int streamId, final Payload payload) {
         reset(streamId, payload);
         type = Type.RESPONSE;
     }
 
-    public void resetForResponseComplete(final int streamId, final Payload payload)
-    {
+    public void resetForResponseComplete(final int streamId, final Payload payload) {
         reset(streamId, payload);
         type = Type.RESPONSE_COMPLETE;
     }
 
-    public void resetForRequestChannel(final int streamId, final Payload payload, final int initialRequestN)
-    {
+    public void resetForRequestChannel(final int streamId, final Payload payload, final int initialRequestN) {
         reset(streamId, payload);
         type = Type.REQUEST_CHANNEL;
         this.initialRequestN = initialRequestN;
     }
 
-    public static boolean requiresFragmenting(final int metadataMtu, final int dataMtu, final Payload payload)
-    {
+    public static boolean requiresFragmenting(final int metadataMtu, final int dataMtu, final Payload payload) {
         final ByteBuffer metadata = payload.getMetadata();
         final ByteBuffer data = payload.getData();
 
         return metadata.remaining() > metadataMtu || data.remaining() > dataMtu;
     }
 
-    public Iterator<Frame> iterator()
-    {
+    public Iterator<Frame> iterator() {
         return this;
     }
 
-    public boolean hasNext()
-    {
+    public boolean hasNext() {
         return dataOffset < data.remaining() || metadataOffset < metadata.remaining();
     }
 
-    public Frame next()
-    {
+    public Frame next() {
         final int metadataLength = Math.min(metadataMtu, metadata.remaining() - metadataOffset);
         final int dataLength = Math.min(dataMtu, data.remaining() - dataOffset);
 
@@ -106,28 +96,21 @@ public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame>
         final boolean isMoreFollowing = metadataOffset < metadata.remaining() || dataOffset < data.remaining();
         int flags = 0;
 
-        if (Type.RESPONSE == type)
-        {
-            if (isMoreFollowing)
-            {
+        if (Type.RESPONSE == type) {
+            if (isMoreFollowing) {
                 flags |= FrameHeaderFlyweight.FLAGS_RESPONSE_F;
             }
 
             result = Frame.Response.from(streamId, FrameType.NEXT, metadataBuffer, dataBuffer, flags);
         }
-        if (Type.RESPONSE_COMPLETE == type)
-        {
-            if (isMoreFollowing)
-            {
+        if (Type.RESPONSE_COMPLETE == type) {
+            if (isMoreFollowing) {
                 flags |= FrameHeaderFlyweight.FLAGS_RESPONSE_F;
             }
 
             result = Frame.Response.from(streamId, FrameType.NEXT_COMPLETE, metadataBuffer, dataBuffer, flags);
-        }
-        else if (Type.REQUEST_CHANNEL == type)
-        {
-            if (isMoreFollowing)
-            {
+        } else if (Type.REQUEST_CHANNEL == type) {
+            if (isMoreFollowing) {
                 flags |= FrameHeaderFlyweight.FLAGS_REQUEST_CHANNEL_F;
             }
 
@@ -138,8 +121,7 @@ public class PayloadFragmenter implements Iterable<Frame>, Iterator<Frame>
         return result;
     }
 
-    private void reset(final int streamId, final Payload payload)
-    {
+    private void reset(final int streamId, final Payload payload) {
         data = payload.getData();
         metadata = payload.getMetadata();
         metadataOffset = 0;

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/RequestFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/RequestFrameFlyweight.java
@@ -23,8 +23,7 @@ import org.agrona.MutableDirectBuffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-public class RequestFrameFlyweight
-{
+public class RequestFrameFlyweight {
 
     private RequestFrameFlyweight() {}
 
@@ -34,12 +33,10 @@ public class RequestFrameFlyweight
     // relative to start of passed offset
     private static final int INITIAL_REQUEST_N_FIELD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;
 
-    public static int computeFrameLength(final FrameType type, final int metadataLength, final int dataLength)
-    {
+    public static int computeFrameLength(final FrameType type, final int metadataLength, final int dataLength) {
         int length = FrameHeaderFlyweight.computeFrameHeaderLength(type, metadataLength, dataLength);
 
-        if (type.hasInitialRequestN())
-        {
+        if (type.hasInitialRequestN()) {
             length += BitUtil.SIZE_OF_INT;
         }
 
@@ -54,8 +51,8 @@ public class RequestFrameFlyweight
         final FrameType type,
         final int initialRequestN,
         final ByteBuffer metadata,
-        final ByteBuffer data)
-    {
+        final ByteBuffer data
+    ) {
         final int frameLength = computeFrameLength(type, metadata.remaining(), data.remaining());
 
         flags |= FLAGS_REQUEST_CHANNEL_N;
@@ -77,8 +74,8 @@ public class RequestFrameFlyweight
         final int flags,
         final FrameType type,
         final ByteBuffer metadata,
-        final ByteBuffer data)
-    {
+        final ByteBuffer data
+    ) {
         final int frameLength = computeFrameLength(type, metadata.remaining(), data.remaining());
 
         int length = FrameHeaderFlyweight.encodeFrameHeader(mutableDirectBuffer, offset, frameLength, flags, type, streamId);
@@ -89,17 +86,14 @@ public class RequestFrameFlyweight
         return length;
     }
 
-    public static int initialRequestN(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int initialRequestN(final DirectBuffer directBuffer, final int offset) {
         return directBuffer.getInt(offset + INITIAL_REQUEST_N_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
-    public static int payloadOffset(final FrameType type, final DirectBuffer directBuffer, final int offset)
-    {
+    public static int payloadOffset(final FrameType type, final DirectBuffer directBuffer, final int offset) {
         int result = offset + FrameHeaderFlyweight.FRAME_HEADER_LENGTH;
 
-        if (type.hasInitialRequestN())
-        {
+        if (type.hasInitialRequestN()) {
             result += BitUtil.SIZE_OF_INT;
         }
 

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/RequestNFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/RequestNFrameFlyweight.java
@@ -22,15 +22,13 @@ import org.agrona.MutableDirectBuffer;
 
 import java.nio.ByteOrder;
 
-public class RequestNFrameFlyweight
-{
+public class RequestNFrameFlyweight {
     private RequestNFrameFlyweight() {}
 
     // relative to start of passed offset
     private static final int REQUEST_N_FIELD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;
 
-    public static int computeFrameLength()
-    {
+    public static int computeFrameLength() {
         int length = FrameHeaderFlyweight.computeFrameHeaderLength(FrameType.REQUEST_N, 0, 0);
 
         return length + BitUtil.SIZE_OF_INT;
@@ -40,8 +38,8 @@ public class RequestNFrameFlyweight
         final MutableDirectBuffer mutableDirectBuffer,
         final int offset,
         final int streamId,
-        final int requestN)
-    {
+        final int requestN
+    ) {
         final int frameLength = computeFrameLength();
 
         int length = FrameHeaderFlyweight.encodeFrameHeader(mutableDirectBuffer, offset, frameLength, 0, FrameType.REQUEST_N, streamId);
@@ -51,13 +49,11 @@ public class RequestNFrameFlyweight
         return length + BitUtil.SIZE_OF_INT;
     }
 
-    public static int requestN(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int requestN(final DirectBuffer directBuffer, final int offset) {
         return directBuffer.getInt(offset + REQUEST_N_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
-    public static int payloadOffset(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int payloadOffset(final DirectBuffer directBuffer, final int offset) {
         return offset + FrameHeaderFlyweight.FRAME_HEADER_LENGTH + BitUtil.SIZE_OF_INT;
     }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
@@ -24,8 +24,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
-public class SetupFrameFlyweight
-{
+public class SetupFrameFlyweight {
     private SetupFrameFlyweight() {}
 
     public static final int FLAGS_WILL_HONOR_LEASE = 0b0010_0000;
@@ -43,8 +42,8 @@ public class SetupFrameFlyweight
         final String metadataMimeType,
         final String dataMimeType,
         final int metadataLength,
-        final int dataLength)
-    {
+        final int dataLength
+    ) {
         int length = FrameHeaderFlyweight.computeFrameHeaderLength(FrameType.SETUP, metadataLength, dataLength);
 
         length += BitUtil.SIZE_OF_INT * 3;
@@ -63,8 +62,8 @@ public class SetupFrameFlyweight
         final String metadataMimeType,
         final String dataMimeType,
         final ByteBuffer metadata,
-        final ByteBuffer data)
-    {
+        final ByteBuffer data
+    ) {
         final int frameLength = computeFrameLength(metadataMimeType, dataMimeType, metadata.remaining(), data.remaining());
 
         int length = FrameHeaderFlyweight.encodeFrameHeader(mutableDirectBuffer, offset, frameLength, flags, FrameType.SETUP, 0);
@@ -84,29 +83,24 @@ public class SetupFrameFlyweight
         return length;
     }
 
-    public static int version(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int version(final DirectBuffer directBuffer, final int offset) {
         return directBuffer.getInt(offset + VERSION_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
-    public static int keepaliveInterval(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int keepaliveInterval(final DirectBuffer directBuffer, final int offset) {
         return directBuffer.getInt(offset + KEEPALIVE_INTERVAL_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
-    public static int maxLifetime(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int maxLifetime(final DirectBuffer directBuffer, final int offset) {
         return directBuffer.getInt(offset + MAX_LIFETIME_FIELD_OFFSET, ByteOrder.BIG_ENDIAN);
     }
 
-    public static String metadataMimeType(final DirectBuffer directBuffer, final int offset)
-    {
+    public static String metadataMimeType(final DirectBuffer directBuffer, final int offset) {
         final byte[] bytes = getMimeType(directBuffer, offset + METADATA_MIME_TYPE_LENGTH_OFFSET);
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
-    public static String dataMimeType(final DirectBuffer directBuffer, final int offset)
-    {
+    public static String dataMimeType(final DirectBuffer directBuffer, final int offset) {
         int fieldOffset = offset + METADATA_MIME_TYPE_LENGTH_OFFSET;
 
         fieldOffset += 1 + directBuffer.getByte(fieldOffset);
@@ -115,8 +109,7 @@ public class SetupFrameFlyweight
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
-    public static int payloadOffset(final DirectBuffer directBuffer, final int offset)
-    {
+    public static int payloadOffset(final DirectBuffer directBuffer, final int offset) {
         int fieldOffset = offset + METADATA_MIME_TYPE_LENGTH_OFFSET;
 
         final int metadataMimeTypeLength = directBuffer.getByte(fieldOffset);
@@ -129,8 +122,7 @@ public class SetupFrameFlyweight
     }
 
     private static int putMimeType(
-        final MutableDirectBuffer mutableDirectBuffer, final int fieldOffset, final String mimeType)
-    {
+        final MutableDirectBuffer mutableDirectBuffer, final int fieldOffset, final String mimeType) {
         byte[] bytes = mimeType.getBytes(StandardCharsets.UTF_8);
 
         mutableDirectBuffer.putByte(fieldOffset, (byte) bytes.length);
@@ -139,8 +131,7 @@ public class SetupFrameFlyweight
         return 1 + bytes.length;
     }
 
-    private static byte[] getMimeType(final DirectBuffer directBuffer, final int fieldOffset)
-    {
+    private static byte[] getMimeType(final DirectBuffer directBuffer, final int fieldOffset) {
         final int length = directBuffer.getByte(fieldOffset);
         final byte[] bytes = new byte[length];
 

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/UnpooledFrame.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/UnpooledFrame.java
@@ -24,42 +24,32 @@ import java.nio.ByteBuffer;
 /**
  * On demand creation for Frames, MutableDirectBuffer backed by ByteBuffers of required capacity
  */
-public class UnpooledFrame implements FramePool
-{
+public class UnpooledFrame implements FramePool {
     /*
      * TODO: have all gneration of UnsafeBuffer and ByteBuffer hidden behind acquire() calls (private for ByteBuffer)
      */
 
-    public Frame acquireFrame(int size)
-    {
+    public Frame acquireFrame(int size) {
         return Frame.allocate(new UnsafeBuffer(ByteBuffer.allocate(size)));
     }
 
-    public Frame acquireFrame(ByteBuffer byteBuffer)
-    {
+    public Frame acquireFrame(ByteBuffer byteBuffer) {
         return Frame.allocate(new UnsafeBuffer(byteBuffer));
     }
 
-    public void release(Frame frame)
-    {
-    }
+    public void release(Frame frame) {}
 
-    public Frame acquireFrame(MutableDirectBuffer mutableDirectBuffer)
-    {
+    public Frame acquireFrame(MutableDirectBuffer mutableDirectBuffer) {
         return Frame.allocate(mutableDirectBuffer);
     }
 
-    public MutableDirectBuffer acquireMutableDirectBuffer(ByteBuffer byteBuffer)
-    {
+    public MutableDirectBuffer acquireMutableDirectBuffer(ByteBuffer byteBuffer) {
         return new UnsafeBuffer(byteBuffer);
     }
 
-    public MutableDirectBuffer acquireMutableDirectBuffer(int size)
-    {
+    public MutableDirectBuffer acquireMutableDirectBuffer(int size) {
         return new UnsafeBuffer(ByteBuffer.allocate(size));
     }
 
-    public void release(MutableDirectBuffer mutableDirectBuffer)
-    {
-    }
+    public void release(MutableDirectBuffer mutableDirectBuffer) {}
 }


### PR DESCRIPTION
***Problem***
There is an error in the Error frame, the error codes used for `APPLICATION_ERROR`,
`CONNECTION_ERROR`, `REJECTED`, `CANCELED` and `INVALID` were invalid.

***Solution***
Update the constants.
I don't think it requires doing any version bump, since the error code was not used
prior to #150.

***Modification***
I also took the oportunity to review the `frame` package and update it to the Java
code style.