### PR TITLE
Fix SETUP flags according to the spec

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/SetupFrameFlyweight.java
@@ -27,8 +27,8 @@ import java.nio.charset.StandardCharsets;
 public class SetupFrameFlyweight {
     private SetupFrameFlyweight() {}
 
-    public static final int FLAGS_WILL_HONOR_LEASE = 0b0010_0000;
-    public static final int FLAGS_STRICT_INTERPRETATION = 0b0001_0000;
+    public static final int FLAGS_WILL_HONOR_LEASE = 0b0010_0000_0000_0000;
+    public static final int FLAGS_STRICT_INTERPRETATION = 0b0001_0000_0000_0000;
 
     public static final byte CURRENT_VERSION = 0;
 


### PR DESCRIPTION
***Problem***
The flags used in the SETUP frame are different from the one defined in the specification.
They are defined as a byte (8bits) vs. a short (16bits)
(See https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#setup-frame)

***Solution***
Update the constant to the right value.