### PR TITLE
use RuntimeException

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/ApplicationException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/ApplicationException.java
@@ -15,7 +15,7 @@
  */
 package io.reactivesocket.exceptions;
 
-public class ApplicationException extends Throwable {
+public class ApplicationException extends RuntimeException {
     public ApplicationException(String message) {
         super(message);
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/CancelException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/CancelException.java
@@ -15,7 +15,7 @@
  */
 package io.reactivesocket.exceptions;
 
-public class CancelException extends Throwable {
+public class CancelException extends RuntimeException {
     public CancelException(String message) {
         super(message);
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/ConnectionException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/ConnectionException.java
@@ -15,7 +15,7 @@
  */
 package io.reactivesocket.exceptions;
 
-public class ConnectionException extends Throwable implements Retryable {
+public class ConnectionException extends RuntimeException implements Retryable {
     public ConnectionException(String message) {
         super(message);
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/InvalidRequestException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/InvalidRequestException.java
@@ -15,7 +15,7 @@
  */
 package io.reactivesocket.exceptions;
 
-public class InvalidRequestException extends Throwable {
+public class InvalidRequestException extends RuntimeException {
     public InvalidRequestException(String message) {
         super(message);
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/RejectedException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/RejectedException.java
@@ -15,7 +15,7 @@
  */
 package io.reactivesocket.exceptions;
 
-public class RejectedException extends Throwable implements Retryable {
+public class RejectedException extends RuntimeException implements Retryable {
     public RejectedException (String message) {
         super(message);
     }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/SetupException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/SetupException.java
@@ -18,7 +18,7 @@ package io.reactivesocket.exceptions;
 import io.reactivesocket.Frame;
 import io.reactivesocket.FrameType;
 
-public class SetupException extends Throwable {
+public class SetupException extends RuntimeException {
 	public SetupException(String message) {
 		super(message);
 	}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/TimeoutException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/TimeoutException.java
@@ -13,7 +13,7 @@
 
 package io.reactivesocket.exceptions;
 
-public class TimeoutException extends Exception {
+public class TimeoutException extends RuntimeException {
 
     private static final long serialVersionUID = -6352901497935205059L;
 

--- a/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/TransportException.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/exceptions/TransportException.java
@@ -15,7 +15,7 @@
  */
 package io.reactivesocket.exceptions;
 
-public class TransportException extends Throwable {
+public class TransportException extends RuntimeException {
     public TransportException(Throwable t) {
         super(t);
     }


### PR DESCRIPTION
Throwable is awkward e.g.

```
java.lang.RuntimeException: io.reactivesocket.exceptions.ApplicationException: St13runtime_error: XXX
	at rx.exceptions.Exceptions.propagate(Exceptions.java:58)
	at rx.Completable.await(Completable.java:1051)
	at io.reactivesocket.cli.Main.run(Main.java:87)
	at io.reactivesocket.cli.Main.main(Main.java:182)
Caused by: io.reactivesocket.exceptions.ApplicationException: St13runtime_error: XXX
```
