### PR TITLE
more app errors please

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ErrorFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/frame/ErrorFrameFlyweight.java
@@ -100,7 +100,7 @@ public class ErrorFrameFlyweight {
         } else if (ex instanceof CancelException) {
             return CANCEL;
         }
-        return INVALID;
+        return APPLICATION_ERROR;
     }
 
     public static int errorCode(final DirectBuffer directBuffer, final int offset) {

--- a/reactivesocket-core/src/test/java/io/reactivesocket/internal/RequesterTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/internal/RequesterTest.java
@@ -21,6 +21,7 @@ import io.reactivesocket.FrameType;
 import io.reactivesocket.LatchedCompletable;
 import io.reactivesocket.Payload;
 import io.reactivesocket.TestConnection;
+import io.reactivesocket.exceptions.ApplicationException;
 import io.reactivesocket.exceptions.InvalidRequestException;
 import io.reactivesocket.util.PayloadImpl;
 import io.reactivex.Observable;
@@ -166,7 +167,7 @@ public class RequesterTest
 
         conn.toInput.send(Frame.Error.from(2, new RuntimeException("Failed")));
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertError(InvalidRequestException.class);
+        ts.assertError(ApplicationException.class);
         assertEquals("Failed", ts.errors().get(0).getMessage());
     }
 
@@ -314,7 +315,7 @@ public class RequesterTest
         conn.toInput.send(utf8EncodedErrorFrame(2, "Failure"));
 
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertError(InvalidRequestException.class);
+        ts.assertError(ApplicationException.class);
         ts.assertValue(utf8EncodedPayload("hello", null));
         assertEquals("Failure", ts.errors().get(0).getMessage());
     }


### PR DESCRIPTION
For discussion:

I'd argue this is the right code because its the behaviour you get with

        requestHandlerBuilder.withRequestResponse(payload ->
                RxReactiveStreams.toPublisher(Observable.error(new Exception("server failure")))).build();

We can't know all errors ahead of time, and I don't think we should ask users to map things to ApplicationError.