### PR TITLE
Do not send lease frames for clients that do not honor leases.

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProvider.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProvider.java
@@ -22,6 +22,7 @@ import io.reactivesocket.lease.DefaultLeaseHonoringSocket;
 import io.reactivesocket.DuplexConnection;
 import io.reactivesocket.Frame;
 import io.reactivesocket.Frame.Setup;
+import io.reactivesocket.lease.DisableLeaseSocket;
 import io.reactivesocket.lease.LeaseHonoringSocket;
 import io.reactivesocket.ReactiveSocket;
 import io.reactivesocket.frame.SetupFrameFlyweight;
@@ -83,6 +84,15 @@ public interface SetupProvider {
      * @return A new {@code SetupProvider} instance.
      */
     SetupProvider disableLease();
+
+    /**
+     * Creates a new {@code SetupProvider} that does not honor leases.
+     *
+     * @param socketFactory A factory to create {@link DisableLeaseSocket} for each accepted socket.
+     *
+     * @return A new {@code SetupProvider} instance.
+     */
+    SetupProvider disableLease(Function<ReactiveSocket, DisableLeaseSocket> socketFactory);
 
     /**
      * Creates a new {@code SetupProvider} that uses the passed {@code setupPayload} as the payload for the setup frame.

--- a/reactivesocket-core/src/main/java/io/reactivesocket/lease/DisableLeaseSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/lease/DisableLeaseSocket.java
@@ -19,11 +19,15 @@ package io.reactivesocket.lease;
 import io.reactivesocket.Payload;
 import io.reactivesocket.ReactiveSocket;
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link LeaseHonoringSocket} that does not expect to receive any leases and {@link #accept(Lease)} throws an error.
  */
 public class DisableLeaseSocket implements LeaseHonoringSocket {
+
+    private static final Logger logger = LoggerFactory.getLogger(DisableLeaseSocket.class);
 
     private final ReactiveSocket delegate;
 
@@ -31,12 +35,9 @@ public class DisableLeaseSocket implements LeaseHonoringSocket {
         this.delegate = delegate;
     }
 
-    /**
-     * @throws IllegalArgumentException Always thrown.
-     */
     @Override
     public void accept(Lease lease) {
-        throw new IllegalArgumentException("Leases are disabled.");
+        logger.info("Leases are disabled but received a lease from the peer. " + lease);
     }
 
     @Override

--- a/reactivesocket-core/src/main/java/io/reactivesocket/lease/LeaseImpl.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/lease/LeaseImpl.java
@@ -57,4 +57,13 @@ public final class LeaseImpl implements Lease {
     public ByteBuffer metadata() {
         return metadata;
     }
+
+    @Override
+    public String toString() {
+        return "LeaseImpl{" +
+               "allowedRequests=" + allowedRequests +
+               ", ttl=" + ttl +
+               ", expiry=" + expiry +
+               '}';
+    }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/server/ReactiveSocketServer.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/server/ReactiveSocketServer.java
@@ -53,6 +53,7 @@ public interface ReactiveSocketServer {
                                                                                  KeepAliveProvider.never());
                           LeaseEnforcingSocket handler = acceptor.accept(setupPayload, sender);
                           ServerReactiveSocket receiver = new ServerReactiveSocket(duplexConnection, handler,
+                                                                                   setupPayload.willClientHonorLease(),
                                                                                    Throwable::printStackTrace);
                           receiver.start();
                           return duplexConnection.onClose();

--- a/reactivesocket-transport-local/src/test/java/io/reactivesocket/ClientDishonorLeaseTest.java
+++ b/reactivesocket-transport-local/src/test/java/io/reactivesocket/ClientDishonorLeaseTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket;
+
+import io.reactivesocket.client.ReactiveSocketClient;
+import io.reactivesocket.lease.DefaultLeaseEnforcingSocket;
+import io.reactivesocket.lease.DefaultLeaseEnforcingSocket.LeaseDistributor;
+import io.reactivesocket.lease.DisableLeaseSocket;
+import io.reactivesocket.lease.Lease;
+import io.reactivesocket.lease.LeaseImpl;
+import io.reactivesocket.local.LocalSendReceiveTest.LocalRule;
+import io.reactivesocket.reactivestreams.extensions.internal.CancellableImpl;
+import io.reactivesocket.server.ReactiveSocketServer;
+import io.reactivesocket.util.PayloadImpl;
+import io.reactivex.Single;
+import io.reactivex.subscribers.TestSubscriber;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+import static io.reactivesocket.client.KeepAliveProvider.*;
+import static io.reactivesocket.client.SetupProvider.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Matchers.*;
+
+public class ClientDishonorLeaseTest {
+
+    @Rule
+    public final LocalRSRule rule = new LocalRSRule();
+
+    @Test(timeout = 10000)
+    public void testNoLeasesSentToClient() throws Exception {
+        ReactiveSocket socket = rule.connectSocket();
+        rule.sendLease();
+
+        TestSubscriber<Payload> s = TestSubscriber.create();
+        socket.requestResponse(PayloadImpl.EMPTY).subscribe(s);
+        s.awaitTerminalEvent();
+
+        assertThat("Unexpected leases received by the client.", rule.leases, is(empty()));
+    }
+
+    public static class LocalRSRule extends LocalRule {
+
+        private ReactiveSocketServer socketServer;
+        private ReactiveSocketClient socketClient;
+        private LeaseDistributor leaseDistributorMock;
+        private List<Lease> leases;
+
+        @Override
+        public Statement apply(final Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    leases = new CopyOnWriteArrayList<>();
+                    leaseDistributorMock = Mockito.mock(LeaseDistributor.class);
+                    Mockito.when(leaseDistributorMock.registerSocket(any())).thenReturn(new CancellableImpl());
+                    init();
+                    socketServer = ReactiveSocketServer.create(localServer);
+                    socketServer.start((setup, sendingSocket) -> {
+                        return new DefaultLeaseEnforcingSocket(new AbstractReactiveSocket() { }, leaseDistributorMock);
+                    });
+                    socketClient = ReactiveSocketClient.create(localClient, keepAlive(never())
+                            .disableLease(reactiveSocket -> new DisableLeaseSocket(reactiveSocket) {
+                                @Override
+                                public void accept(Lease lease) {
+                                    leases.add(lease);
+                                }
+                            }));
+                    base.evaluate();
+                }
+            };
+        }
+
+        public ReactiveSocket connectSocket() {
+            return Single.fromPublisher(socketClient.connect()).blockingGet();
+        }
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        public Consumer<Lease> sendLease() {
+            ArgumentCaptor<Consumer> leaseConsumerCaptor = ArgumentCaptor.forClass(Consumer.class);
+            Mockito.verify(leaseDistributorMock).registerSocket(leaseConsumerCaptor.capture());
+            Consumer<Lease> leaseConsumer = leaseConsumerCaptor.getValue();
+            leaseConsumer.accept(new LeaseImpl(1, 1, Frame.NULL_BYTEBUFFER));
+            return leaseConsumer;
+        }
+    }
+}

--- a/reactivesocket-transport-local/src/test/java/io/reactivesocket/local/LocalSendReceiveTest.java
+++ b/reactivesocket-transport-local/src/test/java/io/reactivesocket/local/LocalSendReceiveTest.java
@@ -67,24 +67,28 @@ public class LocalSendReceiveTest {
 
     public static class LocalRule extends ExternalResource {
 
-        private LocalClient localClient;
-        private String name;
+        protected String name;
+        protected LocalServer localServer;
+        protected LocalClient localClient;
 
         @Override
         public Statement apply(final Statement base, Description description) {
             return new Statement() {
                 @Override
                 public void evaluate() throws Throwable {
-                    name = "test-send-receive-server-" + ThreadLocalRandom.current().nextInt();
-                    LocalServer.create(name)
-                               .start(duplexConnection -> {
-                                   return duplexConnection.send(duplexConnection.receive());
-                               });
-
-                    localClient = LocalClient.create(name);
+                    init();
+                    localServer.start(duplexConnection -> {
+                        return duplexConnection.send(duplexConnection.receive());
+                    });
                     base.evaluate();
                 }
             };
+        }
+
+        protected void init() {
+            name = "test-send-receive-server-" + ThreadLocalRandom.current().nextInt();
+            localServer = LocalServer.create(name);
+            localClient = LocalClient.create(name);
         }
 
         public DuplexConnection connect() {


### PR DESCRIPTION
#### Problem

Today server sends leases even though the client does not honor leases. There are two things here:

- A server should protect itself, even if the client dishonors leases, i.e. leases aren't infinite if the client does not honor. So, the server should still expect requests within capacity from clients and reject all other requests.
- Clients should not receive lease frames as they are not relevant.

#### Modification 

`ServerReactiveSocket` to not send leases when the setup is such that client does not honor leases.
Also, added an override in `SetupProvider` to be able to modify the `DisableLeaseSocket` if required.

#### Result
Expected results and optimizations on the wire w.r.t data transfers.