### PR TITLE
Fix for `requestChannel` and `requestStream`

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/ClientReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ClientReactiveSocket.java
@@ -20,10 +20,13 @@ import io.reactivesocket.client.KeepAliveProvider;
 import io.reactivesocket.exceptions.CancelException;
 import io.reactivesocket.exceptions.Exceptions;
 import io.reactivesocket.internal.KnownErrorFilter;
+import io.reactivesocket.internal.RemoteReceiver;
+import io.reactivesocket.internal.RemoteSender;
 import io.reactivesocket.lease.Lease;
 import io.reactivesocket.lease.LeaseImpl;
 import io.reactivesocket.reactivestreams.extensions.DefaultSubscriber;
 import io.reactivesocket.reactivestreams.extensions.Px;
+import io.reactivesocket.reactivestreams.extensions.internal.ValidatingSubscription;
 import io.reactivesocket.reactivestreams.extensions.internal.processors.ConnectableUnicastProcessor;
 import io.reactivesocket.reactivestreams.extensions.internal.subscribers.CancellableSubscriber;
 import io.reactivesocket.reactivestreams.extensions.internal.subscribers.Subscribers;
@@ -50,8 +53,8 @@ public class ClientReactiveSocket implements ReactiveSocket {
     private final StreamIdSupplier streamIdSupplier;
     private final KeepAliveProvider keepAliveProvider;
 
-    private final Int2ObjectHashMap<Processor<Frame, Frame>> senders;
-    private final Int2ObjectHashMap<Subscriber<? super Payload>> receivers;
+    private final Int2ObjectHashMap<Subscription> senders;
+    private final Int2ObjectHashMap<Subscriber<Frame>> receivers;
 
     private volatile Subscription transportReceiveSubscription;
     private CancellableSubscriber<Void> keepAliveSendSub;
@@ -81,11 +84,12 @@ public class ClientReactiveSocket implements ReactiveSocket {
         }
     }
 
+    @Override
     public Publisher<Payload> requestResponse(Payload payload) {
         final int streamId = nextStreamId();
         final Frame requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_RESPONSE, payload, 1);
 
-        return doSendReceive(Px.just(requestFrame), streamId, 1, false);
+        return handleRequestResponse(Px.just(requestFrame), streamId, 1, false);
     }
 
     @Override
@@ -93,7 +97,7 @@ public class ClientReactiveSocket implements ReactiveSocket {
         final int streamId = nextStreamId();
         final Frame requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_STREAM, payload, 1);
 
-        return doSendReceive(Px.just(requestFrame), streamId, 1, true);
+        return handleStreamResponse(Px.just(requestFrame), streamId);
     }
 
     @Override
@@ -101,66 +105,16 @@ public class ClientReactiveSocket implements ReactiveSocket {
         final int streamId = nextStreamId();
         final Frame requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_SUBSCRIPTION, payload, 1);
 
-        return doSendReceive(Px.just(requestFrame), streamId, 1, true);
+        return handleStreamResponse(Px.just(requestFrame), streamId);
     }
 
     @Override
     public Publisher<Payload> requestChannel(Publisher<Payload> payloads) {
         final int streamId = nextStreamId();
-        Px<Frame> frames = Px
-            .from(payloads)
-            .map(payload -> Frame.Request.from(streamId, FrameType.REQUEST_CHANNEL, payload, 1));
-        return doSendReceive(frames, streamId, 1, true);
-    }
-
-    private Publisher<Payload> doSendReceive(final Publisher<Frame> payload, final int streamId, final int initialRequestN, final boolean sendRequestN) {
-        ConnectableUnicastProcessor<Frame> sender = new ConnectableUnicastProcessor<>();
-
-        synchronized (this) {
-            senders.put(streamId, sender);
-        }
-
-        final Runnable cleanup = () -> {
-            synchronized (this) {
-                receivers.remove(streamId);
-                senders.remove(streamId);
-            }
-        };
-
-        return Px
-            .<Payload>create(subscriber -> {
-                synchronized (this) {
-                    receivers.put(streamId, subscriber);
-                }
-
-                payload.subscribe(sender);
-
-                subscriber.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        if (sendRequestN) {
-                            sender.onNext(Frame.RequestN.from(streamId, n));
-                        }
-                    }
-
-                    @Override
-                    public void cancel() {
-                        sender.onNext(Frame.Cancel.from(streamId));
-                        sender.cancel();
-                    }
-                });
-
-                try {
-                    Px.from(connection.send(sender))
-                      .doOnError(th -> subscriber.onError(th))
-                      .subscribe(DefaultSubscriber.defaultInstance());
-                } catch (Throwable t) {
-                    subscriber.onError(t);
-                }
-            })
-            .doOnRequest(subscription -> sender.start(initialRequestN))
-            .doOnTerminate(cleanup);
+        return handleStreamResponse(Px.from(payloads)
+                                      .map(payload -> {
+                                   return Frame.Request.from(streamId, FrameType.REQUEST_CHANNEL, payload, 1);
+                               }), streamId);
     }
 
     @Override
@@ -192,6 +146,79 @@ public class ClientReactiveSocket implements ReactiveSocket {
         startKeepAlive();
         startReceivingRequests();
         return this;
+    }
+
+    private Publisher<Payload> handleRequestResponse(final Publisher<Frame> payload, final int streamId,
+                                                     final int initialRequestN, final boolean sendRequestN) {
+        ConnectableUnicastProcessor<Frame> sender = new ConnectableUnicastProcessor<>();
+
+        synchronized (this) {
+            senders.put(streamId, sender);
+        }
+
+        final Runnable cleanup = () -> {
+            synchronized (this) {
+                receivers.remove(streamId);
+                senders.remove(streamId);
+            }
+        };
+
+        return Px
+                .<Payload>create(subscriber -> {
+                    @SuppressWarnings("rawtypes")
+                    Subscriber raw = subscriber;
+                    @SuppressWarnings("unchecked")
+                    Subscriber<Frame> fs = raw;
+                    synchronized (this) {
+                        receivers.put(streamId, fs);
+                    }
+
+                    payload.subscribe(sender);
+
+                    subscriber.onSubscribe(new Subscription() {
+
+                        @Override
+                        public void request(long n) {
+                            if (sendRequestN) {
+                                sender.onNext(Frame.RequestN.from(streamId, n));
+                            }
+                        }
+
+                        @Override
+                        public void cancel() {
+                            sender.onNext(Frame.Cancel.from(streamId));
+                            sender.cancel();
+                        }
+                    });
+
+                    Px.from(connection.send(sender))
+                      .doOnError(th -> subscriber.onError(th))
+                      .subscribe(DefaultSubscriber.defaultInstance());
+
+                })
+                .doOnRequest(subscription -> sender.start(initialRequestN))
+                .doOnTerminate(cleanup);
+    }
+
+    private Publisher<Payload> handleStreamResponse(Publisher<Frame> request, final int streamId) {
+        RemoteSender sender = new RemoteSender(request, () -> senders.remove(streamId), streamId, 1);
+        Publisher<Frame> src = s -> {
+            CancellableSubscriber<Void> sendSub = doOnError(throwable -> {
+                s.onError(throwable);
+            });
+            ValidatingSubscription<? super Frame> sub = ValidatingSubscription.create(s, () -> {
+                sendSub.cancel();
+            }, requestN -> {
+                transportReceiveSubscription.request(requestN);
+            });
+            connection.send(sender).subscribe(sendSub);
+            s.onSubscribe(sub);
+        };
+
+        RemoteReceiver receiver = new RemoteReceiver(src, connection, streamId, () -> receivers.remove(streamId), true);
+        senders.put(streamId, sender);
+        receivers.put(streamId, receiver);
+        return receiver;
     }
 
     private void startKeepAlive() {
@@ -254,7 +281,7 @@ public class ClientReactiveSocket implements ReactiveSocket {
 
     @SuppressWarnings("unchecked")
     private void handleFrame(int streamId, FrameType type, Frame frame) {
-        Subscriber<? super Payload> receiver;
+        Subscriber<Frame> receiver;
         synchronized (this) {
             receiver = receivers.get(streamId);
         }
@@ -270,13 +297,13 @@ public class ClientReactiveSocket implements ReactiveSocket {
                     receiver.onComplete();
                     break;
                 case CANCEL: {
-                    Processor sender;
-                    synchronized (ClientReactiveSocket.this) {
+                    Subscription sender;
+                    synchronized (this) {
                         sender = senders.remove(streamId);
                         receivers.remove(streamId);
                     }
                     if (sender != null) {
-                        ((ConnectableUnicastProcessor) sender).cancel();
+                        sender.cancel();
                     }
                     receiver.onError(new CancelException("cancelling stream id " + streamId));
                     break;
@@ -285,13 +312,13 @@ public class ClientReactiveSocket implements ReactiveSocket {
                     receiver.onNext(frame);
                     break;
                 case REQUEST_N: {
-                    Processor sender;
-                    synchronized (ClientReactiveSocket.this) {
+                    Subscription sender;
+                    synchronized (this) {
                         sender = senders.get(streamId);
                     }
                     if (sender != null) {
                         int n = Frame.RequestN.requestN(frame);
-                        ((ConnectableUnicastProcessor) sender).requestMore(n);
+                        sender.request(n);
                     }
                     break;
                 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
@@ -39,6 +39,9 @@ import static java.lang.System.getProperty;
  * This provides encoding, decoding and field accessors.
  */
 public class Frame implements Payload {
+
+    private static final Logger logger = LoggerFactory.getLogger(Frame.class);
+
     public static final ByteBuffer NULL_BYTEBUFFER = FrameHeaderFlyweight.NULL_BYTEBUFFER;
     public static final int DATA_MTU = 32 * 1024;
     public static final int METADATA_MTU = 32 * 1024;
@@ -55,11 +58,11 @@ public class Frame implements Payload {
         FramePool tmpPool;
 
         try {
-            System.out.println("Creating thread pooled named " + FRAME_POOLER_CLASS_NAME);
+            logger.info("Creating thread pooled named " + FRAME_POOLER_CLASS_NAME);
             tmpPool = (FramePool)Class.forName(FRAME_POOLER_CLASS_NAME).newInstance();
         }
         catch (final Exception ex) {
-            ex.printStackTrace();
+            logger.error("Error initializing frame pool.", ex);
             tmpPool = new UnpooledFrame();
         }
 
@@ -299,7 +302,7 @@ public class Frame implements Payload {
     }
 
     public static class Error {
-        private static final Logger logger = LoggerFactory.getLogger(Error.class);
+        private static final Logger errorLogger = LoggerFactory.getLogger(Error.class);
 
         private Error() {}
 
@@ -313,8 +316,8 @@ public class Frame implements Payload {
             final Frame frame = POOL.acquireFrame(
                 ErrorFrameFlyweight.computeFrameLength(metadata.remaining(), data.remaining()));
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("an error occurred, creating error frame", throwable);
+            if (errorLogger.isDebugEnabled()) {
+                errorLogger.debug("an error occurred, creating error frame", throwable);
             }
 
             frame.length = ErrorFrameFlyweight.encode(

--- a/reactivesocket-examples/build.gradle
+++ b/reactivesocket-examples/build.gradle
@@ -45,4 +45,6 @@ dependencies {
     compile 'org.slf4j:slf4j-log4j12:1.7.21'
 
     jmh group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: '1.15'
+
+    compile 'org.slf4j:slf4j-log4j12:1.7.21'
 }

--- a/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/channel/ChannelEchoClient.java
+++ b/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/channel/ChannelEchoClient.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.examples.transport.tcp.channel;
+
+import io.reactivesocket.AbstractReactiveSocket;
+import io.reactivesocket.ConnectionSetupPayload;
+import io.reactivesocket.Payload;
+import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.client.ReactiveSocketClient;
+import io.reactivesocket.frame.ByteBufferUtil;
+import io.reactivesocket.lease.DisabledLeaseAcceptingSocket;
+import io.reactivesocket.lease.LeaseEnforcingSocket;
+import io.reactivesocket.server.ReactiveSocketServer;
+import io.reactivesocket.server.ReactiveSocketServer.SocketAcceptor;
+import io.reactivesocket.transport.TransportServer.StartedServer;
+import io.reactivesocket.transport.tcp.client.TcpTransportClient;
+import io.reactivesocket.transport.tcp.server.TcpTransportServer;
+import io.reactivesocket.util.PayloadImpl;
+import io.reactivesocket.util.ReactiveSocketDecorator;
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
+
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static io.reactivesocket.client.KeepAliveProvider.*;
+import static io.reactivesocket.client.SetupProvider.*;
+
+public final class ChannelEchoClient {
+
+    public static void main(String[] args) {
+        StartedServer server = ReactiveSocketServer.create(TcpTransportServer.create())
+                                                   .start(new SocketAcceptorImpl());
+
+        SocketAddress address = server.getServerAddress();
+        ReactiveSocket socket = Flowable.fromPublisher(ReactiveSocketClient.create(TcpTransportClient.create(address),
+                                                                                   keepAlive(never()).disableLease())
+                                                                           .connect())
+                                        .blockingFirst();
+
+        Flowable.fromPublisher(socket.requestChannel(Flowable.interval(0, 100, TimeUnit.MILLISECONDS)
+                                                             .map(i -> "Hello - " + i)
+                                                             .<Payload>map(PayloadImpl::new)
+                                                             .repeat()))
+                .map(payload -> payload.getData())
+                .map(ByteBufferUtil::toUtf8String)
+                .doOnNext(System.out::println)
+                .take(10)
+                .concatWith(Flowable.fromPublisher(socket.close()).cast(String.class))
+                .blockingLast();
+    }
+
+    private static class SocketAcceptorImpl implements SocketAcceptor {
+        @Override
+        public LeaseEnforcingSocket accept(ConnectionSetupPayload setupPayload, ReactiveSocket reactiveSocket) {
+            return new DisabledLeaseAcceptingSocket(new AbstractReactiveSocket() {
+                @Override
+                public Publisher<Payload> requestChannel(Publisher<Payload> payloads) {
+                    return Flowable.fromPublisher(payloads)
+                                   .map(Payload::getData)
+                                   .map(ByteBufferUtil::toUtf8String)
+                                   .map(s -> "Echo: " + s)
+                                   .map(PayloadImpl::new);
+                }
+            });
+        }
+    }
+}

--- a/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/requestresponse/HelloWorldClient.java
+++ b/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/requestresponse/HelloWorldClient.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.reactivesocket.examples.helloworld;
+package io.reactivesocket.examples.transport.tcp.requestresponse;
 
 import io.reactivesocket.AbstractReactiveSocket;
 import io.reactivesocket.Payload;

--- a/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/stream/StreamingClient.java
+++ b/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/stream/StreamingClient.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.examples.transport.tcp.stream;
+
+import io.reactivesocket.AbstractReactiveSocket;
+import io.reactivesocket.ConnectionSetupPayload;
+import io.reactivesocket.Payload;
+import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.client.ReactiveSocketClient;
+import io.reactivesocket.frame.ByteBufferUtil;
+import io.reactivesocket.lease.DisabledLeaseAcceptingSocket;
+import io.reactivesocket.lease.LeaseEnforcingSocket;
+import io.reactivesocket.server.ReactiveSocketServer;
+import io.reactivesocket.server.ReactiveSocketServer.SocketAcceptor;
+import io.reactivesocket.transport.TransportServer.StartedServer;
+import io.reactivesocket.transport.tcp.client.TcpTransportClient;
+import io.reactivesocket.transport.tcp.server.TcpTransportServer;
+import io.reactivesocket.util.PayloadImpl;
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
+
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static io.reactivesocket.client.KeepAliveProvider.*;
+import static io.reactivesocket.client.SetupProvider.*;
+
+public final class StreamingClient {
+
+    public static void main(String[] args) {
+        StartedServer server = ReactiveSocketServer.create(TcpTransportServer.create())
+                                                   .start(new SocketAcceptorImpl());
+
+        SocketAddress address = server.getServerAddress();
+        ReactiveSocket socket = Flowable.fromPublisher(ReactiveSocketClient.create(TcpTransportClient.create(address),
+                                                                                   keepAlive(never()).disableLease())
+                                                                           .connect())
+                                        .blockingFirst();
+
+        Flowable.fromPublisher(socket.requestStream(new PayloadImpl("Hello")))
+                .map(payload -> payload.getData())
+                .map(ByteBufferUtil::toUtf8String)
+                .doOnNext(System.out::println)
+                .take(10)
+                .concatWith(Flowable.fromPublisher(socket.close()).cast(String.class))
+                .blockingLast();
+    }
+
+    private static class SocketAcceptorImpl implements SocketAcceptor {
+        @Override
+        public LeaseEnforcingSocket accept(ConnectionSetupPayload setupPayload, ReactiveSocket reactiveSocket) {
+            return new DisabledLeaseAcceptingSocket(new AbstractReactiveSocket() {
+                @Override
+                public Publisher<Payload> requestStream(Payload payload) {
+                    return Flowable.interval(100, TimeUnit.MILLISECONDS)
+                                   .map(aLong -> new PayloadImpl("Interval: " + aLong));
+                }
+            });
+        }
+    }
+}

--- a/reactivesocket-examples/src/main/resources/log4j.properties
+++ b/reactivesocket-examples/src/main/resources/log4j.properties
@@ -17,4 +17,4 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] (%F:%L) - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%c %d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] (%F:%L) - %m%n

--- a/reactivesocket-examples/src/test/java/io/reactivesocket/integration/StressTest.java
+++ b/reactivesocket-examples/src/test/java/io/reactivesocket/integration/StressTest.java
@@ -1,19 +1,16 @@
 /*
  * Copyright 2016 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
  */
-package io.reactivesocket.examples;
+package io.reactivesocket.integration;
 
 import io.reactivesocket.AbstractReactiveSocket;
 import io.reactivesocket.Payload;

--- a/reactivesocket-publishers/src/main/java/io/reactivesocket/reactivestreams/extensions/internal/processors/ConnectableUnicastProcessor.java
+++ b/reactivesocket-publishers/src/main/java/io/reactivesocket/reactivestreams/extensions/internal/processors/ConnectableUnicastProcessor.java
@@ -27,19 +27,19 @@ import org.reactivestreams.Subscription;
  * has subscribed to a Publisher. It has a method requestMore that lets you limit the number of items being requested in addition
  * to the items being requested from the subscriber.
  */
-public class ConnectableUnicastProcessor<T> implements Processor<T,T>, Px<T> {
+public class ConnectableUnicastProcessor<T> implements Processor<T,T>, Px<T>, Subscription {
     private Subscription subscription;
 
-    private long destinationRequested = 0;
-    private long externallyRequested = 0;
-    private long actuallyRequested = 0;
+    private long destinationRequested;
+    private long externallyRequested;
+    private long actuallyRequested;
 
     private Subscriber<? super T> destination;
 
     private boolean complete;
     private boolean erred;
     private boolean cancelled;
-    private boolean stated = false;
+    private boolean stated;
 
     private Throwable error;
 
@@ -137,6 +137,7 @@ public class ConnectableUnicastProcessor<T> implements Processor<T,T>, Px<T> {
         return !complete && !erred && !cancelled;
     }
 
+    @Override
     public void cancel() {
         synchronized (this) {
             cancelled = true;
@@ -158,10 +159,11 @@ public class ConnectableUnicastProcessor<T> implements Processor<T,T>, Px<T> {
 
             stated = true;
         }
-        requestMore(request);
+        request(request);
     }
 
-    public void requestMore(long request) {
+    @Override
+    public void request(long request) {
         if (canEmit()) {
             synchronized (this) {
                 externallyRequested = FlowControlHelper.incrementRequestN(externallyRequested, request);


### PR DESCRIPTION
__This contains #185, so do not merge this first, it is just a headsup for review__

#### Problem
In the current implementation stream and channel methods are broken.

#### Modification
Fixed stream and channel methods to work end to end. Also added examples for the same.
They are now implemented using the existing `RemoteReceiver` and `RemoteSender` classes.
One major problem with using `ConnectableUnicastProcessor` was that it does not discriminate between subscriber of request and sender of `requestN` and `cancel` frames. So, if the request source is completed, sending `requestN` and `cancel` frames result in them being rejected by the transport. This is one of the reasons `RemoteReceiver` and `RemoteSender` classes were created.

 __request-response implementation is not changed in this change as that needs to be optimized for a single item request-response__

#### Result
Channel and stream work now.