### PR TITLE
Proper shutdown on underlying connection close.

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/lease/DefaultLeaseEnforcingSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/lease/DefaultLeaseEnforcingSocket.java
@@ -17,8 +17,10 @@
 package io.reactivesocket.lease;
 
 import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.reactivestreams.extensions.Px;
 import io.reactivesocket.reactivestreams.extensions.internal.Cancellable;
 import io.reactivesocket.reactivestreams.extensions.internal.subscribers.Subscribers;
+import org.reactivestreams.Publisher;
 
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
@@ -54,6 +56,14 @@ public class DefaultLeaseEnforcingSocket extends DefaultLeaseHonoringSocket impl
 
     public LeaseDistributor getLeaseDistributor() {
         return leaseDistributor;
+    }
+
+    @Override
+    public Publisher<Void> close() {
+        return Px.from(super.close())
+                 .doOnSubscribe(subscription -> {
+                     leaseDistributor.shutdown();
+                 });
     }
 
     /**


### PR DESCRIPTION
#### Problem

`ClientReactiveSocket` and `ServerReactiveSocket` does not cleanup state (unsubscribe keepalive, leases, etc) when the underlying connection is closed by the peer.
This causes lingering keepAlive and lease writes which keeps failing and emitting errors.

#### Modification

Listen to `DuplexConnection.onClose()` and cleanup when that publisher terminates.

#### Result

Cleaner shutdown on close of connection.