### PR TITLE
Fix to publish Snapshots to jfrog

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.reactivesocket:reactivesocket:0.0.1-SNAPSHOT'
+    compile 'io.reactivesocket:reactivesocket:0.5.0-SNAPSHOT'
 }
 ```
 

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -6,7 +6,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   ./gradlew -Prelease.useLastTag=true build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build snapshot --stacktrace
+  ./gradlew -Prelease.version=0.5.0-SNAPSHOT -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build snapshot --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final --stacktrace


### PR DESCRIPTION
#### Problem

Currently travis is publishing 0.2.3-SNAPSHOT artifacts for 0.5.x branch.

#### Modifications

I am not 100% sure if this is the correct way to make travis publish the correct version, but it is a way!
Modified `buildViaTravis.sh` to override the version, just for snapshot builds.

#### Result

Correct version number for snapshot.