### PR TITLE
added sliding window histogram

### DIFF
--- a/reactivesocket-stats-servo/src/main/java/io/reactivesocket/loadbalancer/servo/internal/HdrHistogramMaxGauge.java
+++ b/reactivesocket-stats-servo/src/main/java/io/reactivesocket/loadbalancer/servo/internal/HdrHistogramMaxGauge.java
@@ -25,9 +25,9 @@ import org.HdrHistogram.Histogram;
  * Gauge that wraps a {@link Histogram} and when its polled returns it's max
  */
 public class HdrHistogramMaxGauge extends NumberGauge {
-    private final Histogram histogram;
+    private final SlidingWindowHistogram histogram;
 
-    public HdrHistogramMaxGauge(MonitorConfig monitorConfig, Histogram histogram) {
+    public HdrHistogramMaxGauge(MonitorConfig monitorConfig, SlidingWindowHistogram histogram) {
         super(monitorConfig);
         this.histogram = histogram;
 
@@ -36,6 +36,6 @@ public class HdrHistogramMaxGauge extends NumberGauge {
 
     @Override
     public Long getValue() {
-        return histogram.getMaxValue();
+        return histogram.aggregateHistogram().getMaxValue();
     }
 }

--- a/reactivesocket-stats-servo/src/main/java/io/reactivesocket/loadbalancer/servo/internal/HdrHistogramMinGauge.java
+++ b/reactivesocket-stats-servo/src/main/java/io/reactivesocket/loadbalancer/servo/internal/HdrHistogramMinGauge.java
@@ -25,9 +25,9 @@ import org.HdrHistogram.Histogram;
  * Gauge that wraps a {@link Histogram} and when its polled returns it's min
  */
 public class HdrHistogramMinGauge extends NumberGauge {
-    private final Histogram histogram;
+    private final SlidingWindowHistogram histogram;
 
-    public HdrHistogramMinGauge(MonitorConfig monitorConfig, Histogram histogram) {
+    public HdrHistogramMinGauge(MonitorConfig monitorConfig, SlidingWindowHistogram histogram) {
         super(monitorConfig);
         this.histogram = histogram;
 
@@ -36,6 +36,6 @@ public class HdrHistogramMinGauge extends NumberGauge {
 
     @Override
     public Long getValue() {
-        return histogram.getMinValue();
+        return histogram.aggregateHistogram().getMinValue();
     }
 }

--- a/reactivesocket-stats-servo/src/main/java/io/reactivesocket/loadbalancer/servo/internal/SlidingWindowHistogram.java
+++ b/reactivesocket-stats-servo/src/main/java/io/reactivesocket/loadbalancer/servo/internal/SlidingWindowHistogram.java
@@ -1,0 +1,107 @@
+package io.reactivesocket.loadbalancer.servo.internal;
+
+import org.HdrHistogram.ConcurrentHistogram;
+import org.HdrHistogram.Histogram;
+
+import java.io.PrintStream;
+import java.util.ArrayDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Wraps HdrHistogram to create a sliding window of n histogramQueue. Default window number is five.
+ */
+public class SlidingWindowHistogram {
+    private static final ThreadLocal<Histogram> AGGREGATE_HISTOGRAM = ThreadLocal.withInitial(SlidingWindowHistogram::createHistogram);
+
+    private final AtomicReference<Histogram> histogramAtomicReference;
+
+    private final ArrayDeque<Histogram> histogramQueue;
+
+    public SlidingWindowHistogram() {
+        this(5);
+    }
+
+    public SlidingWindowHistogram(final int numOfWindows) {
+        if (numOfWindows < 2) {
+            throw new IllegalArgumentException("number of windows must be greater than 1");
+        }
+        this.histogramQueue = new ArrayDeque<>(numOfWindows - 1);
+        this.histogramAtomicReference = new AtomicReference<>(createHistogram());
+
+        for (int i = 0; i < numOfWindows - 1; i++) {
+            histogramQueue.offer(createHistogram());
+        }
+    }
+
+    private static Histogram createHistogram() {
+        ConcurrentHistogram histogram = new ConcurrentHistogram(TimeUnit.MINUTES.toNanos(1), 2);
+        histogram.setAutoResize(true);
+        return histogram;
+    }
+
+    /**
+     * Records a value to the in window histogramAtomicReference
+     *
+     * @param value value to record
+     */
+    public void recordValue(long value) {
+        histogramAtomicReference.get().recordValue(value);
+    }
+
+    /**
+     * Slides the Histogram window. Pops a Histogram off a queue, resets it, and places the old
+     * on in the queue.
+     */
+    public void rotateHistogram() {
+        histogramAtomicReference
+            .updateAndGet(old -> {
+                Histogram onDeck;
+                synchronized (this) {
+                    onDeck = histogramQueue.poll();
+                }
+
+                if (onDeck != null) {
+                    onDeck.reset();
+                    synchronized (this) {
+                        histogramQueue.offer(old);
+                    }
+                    return onDeck;
+                } else {
+                    return old;
+                }
+
+            });
+    }
+
+    /**
+     * Aggregates the Histograms into a single histogramAtomicReference and returns it.
+     *
+     * @return Aggregated histogramAtomicReference
+     */
+    public Histogram aggregateHistogram() {
+        Histogram aggregate = AGGREGATE_HISTOGRAM.get();
+        aggregate.reset();
+
+        aggregate.add(histogramAtomicReference.get());
+
+        synchronized (this) {
+            histogramQueue
+                .forEach(aggregate::add);
+        }
+
+        return aggregate;
+    }
+
+    /**
+     * Prints HdrHistogram to System.out
+     */
+    public void print() {
+        print(System.out);
+    }
+
+    public void print(PrintStream printStream) {
+        aggregateHistogram().outputPercentileDistribution(printStream, 1000.0);
+    }
+
+}

--- a/reactivesocket-stats-servo/src/test/java/io/reactivesocket/loadbalancer/servo/internal/SlidingWindowHistogramTest.java
+++ b/reactivesocket-stats-servo/src/test/java/io/reactivesocket/loadbalancer/servo/internal/SlidingWindowHistogramTest.java
@@ -1,0 +1,62 @@
+package io.reactivesocket.loadbalancer.servo.internal;
+
+import org.HdrHistogram.Histogram;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SlidingWindowHistogramTest {
+    @Test
+    public void test() {
+        SlidingWindowHistogram slidingWindowHistogram = new SlidingWindowHistogram(2);
+
+        for (int i = 0; i < 100_000; i++) {
+            slidingWindowHistogram.recordValue(i);
+        }
+
+        slidingWindowHistogram.print();
+        slidingWindowHistogram.rotateHistogram();
+        Histogram histogram =
+            slidingWindowHistogram.aggregateHistogram();
+
+        long totalCount = histogram.getTotalCount();
+        Assert.assertTrue(totalCount == 100_000);
+
+        long p90 = histogram.getValueAtPercentile(90);
+        Assert.assertTrue(p90 < 100_000);
+
+        for (int i = 0; i < 100_000; i++) {
+            slidingWindowHistogram.recordValue(i * 10_000);
+        }
+
+        slidingWindowHistogram.print();
+        slidingWindowHistogram.rotateHistogram();
+
+        histogram =
+            slidingWindowHistogram.aggregateHistogram();
+
+        p90 = histogram.getValueAtPercentile(90);
+        Assert.assertTrue(p90 >= 100_000);
+
+        for (int i = 0; i < 100_000; i++) {
+            slidingWindowHistogram.recordValue(i);
+        }
+
+        slidingWindowHistogram.print();
+        slidingWindowHistogram.rotateHistogram();
+
+        for (int i = 0; i < 100_000; i++) {
+            slidingWindowHistogram.recordValue(i);
+        }
+
+        slidingWindowHistogram.print();
+
+        histogram =
+            slidingWindowHistogram.aggregateHistogram();
+
+        totalCount = histogram.getTotalCount();
+        Assert.assertTrue(totalCount == 200_000);
+
+        p90 = histogram.getValueAtPercentile(90);
+        Assert.assertTrue(p90 < 100_000);
+    }
+}


### PR DESCRIPTION
Problem
Current histogram doesn't resets on every get on every dimension. This creates choppy metrics.

Modifications
Modified the timer to have n histrograms in a queue and rotate of over them to smooth out the histogram over a sliding window. Switched the dimensions of the histrogram to a label called value. Switched the reseting of the histrogram to a closure that is called by the timer instead so it will rotate the histrogram once per window.

Result
Correct metrics over a rolling window.