### PR TITLE
Empty Payload Response treated as Complete frame

### DIFF
--- a/reactivesocket-core/src/test/java/io/reactivesocket/ServerReactiveSocketTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/ServerReactiveSocketTest.java
@@ -29,9 +29,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class ServerReactiveSocketTest {
 
@@ -60,7 +58,8 @@ public class ServerReactiveSocketTest {
         assertThat("Unexpected error.", rule.errors, is(empty()));
         TestSubscriber<Frame> sendSub = sendSubscribers.iterator().next();
         sendSub.request(2);
-        assertThat("Unexpected frame sent.", rule.connection.awaitSend().getType(), is(FrameType.COMPLETE));
+        assertThat("Unexpected frame sent.", rule.connection.awaitSend().getType(),
+                   anyOf(is(FrameType.COMPLETE), is(FrameType.NEXT_COMPLETE)));
     }
 
     @Test(timeout = 2000)

--- a/reactivesocket-core/src/test/java/io/reactivesocket/internal/RemoteSenderTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/internal/RemoteSenderTest.java
@@ -77,7 +77,7 @@ public class RemoteSenderTest {
         receiverSub.assertValue(new Predicate<Frame>() {
             @Override
             public boolean test(Frame frame) throws Exception {
-                return frame.getType() == FrameType.COMPLETE;
+                return frame.getType() == FrameType.COMPLETE || frame.getType() == FrameType.NEXT_COMPLETE;
             }
         });
 
@@ -138,7 +138,7 @@ public class RemoteSenderTest {
         receiverSub.assertValue(new Predicate<Frame>() {
             @Override
             public boolean test(Frame frame) throws Exception {
-                return frame.getType() == FrameType.COMPLETE;
+                return frame.getType() == FrameType.COMPLETE || frame.getType() == FrameType.NEXT_COMPLETE;
             }
         });
         receiverSub.assertNoErrors();

--- a/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/requestresponse/HelloWorldClient.java
+++ b/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/requestresponse/HelloWorldClient.java
@@ -55,10 +55,10 @@ public final class HelloWorldClient {
                                                               .connect())
                                     .blockingFirst();
 
-        Flowable.fromPublisher(socket.requestResponse(new PayloadImpl("Hello")))
+        Flowable.fromPublisher(socket.requestResponse(PayloadImpl.EMPTY))
                 .map(payload -> payload.getData())
                 .map(ByteBufferUtil::toUtf8String)
-                .doOnNext(System.out::println)
+                .doOnNext(x -> System.out.println("===>>>> " + x))
                 .concatWith(Flowable.fromPublisher(socket.close()).cast(String.class))
                 .blockingFirst();
     }


### PR DESCRIPTION
#### Problem

`FrameHeaderFlyweight` resolves the frame type as `NEXT_COMPLETE` only if the payload is not empty. Otherwise, the frame is treated as `COMPLETE`.
This is a problem for request-response as this means the response publisher will complete without emitting a response, if the response does not have any data. Such a condition is a failure as request-response should have exaclty one response.

 #### Modification

 Eliminated the check for data length and always emit `NEXT_COMPLETE` if the complete flag is set.
 According to the [protocol](https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#response-frame):

 ```
 A Response is generally referred to as a NEXT.
 ```

 So, this behavior would not be a violation of the protocol but will produce empty `onNext` before `onComplete`

 #### Result

 Better behavior with empty responses.