### PR TITLE
Remove Cyclic Dependency

### DIFF
--- a/reactivesocket-core/build.gradle
+++ b/reactivesocket-core/build.gradle
@@ -39,7 +39,5 @@ jmh {
 dependencies {
     compile project(':reactivesocket-publishers')
 
-    testCompile project(':reactivesocket-test')
-
     jmh group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: '1.15'
 }


### PR DESCRIPTION
This fixes a cyclic dependency that causes the build to break in Eclipse (with both Gradle plugins).

All tests pass when I run locally, such as:

> ./gradlew :reactivesocket-core:test
> ./gradlew test

So, reactivesocket-core must not actually depend on this ... which would make sense since reactivesocket-test depends on reactivesocket-core, which can't happen.

Despite it building successfully for me locally from command line, I don't know if this has broken something else, so need to see it go through the Travis CI build/test cycle. 