### PR TITLE
Server and Client event publishing

### DIFF
--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/LoadBalancingClient.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/LoadBalancingClient.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
  * An implementation of {@code ReactiveSocketClient} that operates on a cluster of target servers instead of a single
  * server.
  */
-public class LoadBalancingClient implements ReactiveSocketClient {
+public class LoadBalancingClient extends AbstractReactiveSocketClient {
 
     private final LoadBalancerInitializer initializer;
 

--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/FailureAwareClient.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/FailureAwareClient.java
@@ -16,6 +16,7 @@
 package io.reactivesocket.client.filter;
 
 import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.client.AbstractReactiveSocketClient;
 import io.reactivesocket.client.ReactiveSocketClient;
 import io.reactivesocket.reactivestreams.extensions.Px;
 import io.reactivesocket.stat.Ewma;
@@ -34,7 +35,7 @@ import java.util.function.Function;
  * lot of them when sending messages, we will still decrease the availability of the child
  * reducing the probability of connecting to it.
  */
-public class FailureAwareClient implements ReactiveSocketClient {
+public class FailureAwareClient extends AbstractReactiveSocketClient {
 
     private static final double EPSILON = 1e-4;
 
@@ -44,6 +45,7 @@ public class FailureAwareClient implements ReactiveSocketClient {
     private final Ewma errorPercentage;
 
     public FailureAwareClient(ReactiveSocketClient delegate, long halfLife, TimeUnit unit) {
+        super(delegate);
         this.delegate = delegate;
         this.tau = Clock.unit().convert((long)(halfLife / Math.log(2)), unit);
         this.stamp = Clock.now();

--- a/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/ReactiveSocketClients.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/client/filter/ReactiveSocketClients.java
@@ -17,6 +17,7 @@
 package io.reactivesocket.client.filter;
 
 import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.client.AbstractReactiveSocketClient;
 import io.reactivesocket.client.ReactiveSocketClient;
 import io.reactivesocket.reactivestreams.extensions.Px;
 import io.reactivesocket.reactivestreams.extensions.Scheduler;
@@ -47,7 +48,7 @@ public final class ReactiveSocketClients {
      */
     public static ReactiveSocketClient connectTimeout(ReactiveSocketClient orig, long timeout, TimeUnit unit,
                                                       Scheduler scheduler) {
-        return new ReactiveSocketClient() {
+        return new AbstractReactiveSocketClient(orig) {
             @Override
             public Publisher<? extends ReactiveSocket> connect() {
                 return Px.from(orig.connect()).timeout(timeout, unit, scheduler);
@@ -82,7 +83,7 @@ public final class ReactiveSocketClients {
      * @return A new client wrapping the original.
      */
     public static ReactiveSocketClient wrap(ReactiveSocketClient orig, Function<ReactiveSocket, ReactiveSocket> mapper) {
-        return new ReactiveSocketClient() {
+        return new AbstractReactiveSocketClient(orig) {
             @Override
             public Publisher<? extends ReactiveSocket> connect() {
                 return Px.from(orig.connect()).map(mapper::apply);

--- a/reactivesocket-client/src/test/java/io/reactivesocket/client/FailureReactiveSocketTest.java
+++ b/reactivesocket-client/src/test/java/io/reactivesocket/client/FailureReactiveSocketTest.java
@@ -114,7 +114,7 @@ public class FailureReactiveSocketTest {
                 throw new RuntimeException();
             }
         });
-        ReactiveSocketClient factory = new ReactiveSocketClient() {
+        ReactiveSocketClient factory = new AbstractReactiveSocketClient() {
             @Override
             public Publisher<ReactiveSocket> connect() {
                 return subscriber -> {

--- a/reactivesocket-client/src/test/java/io/reactivesocket/client/LoadBalancerTest.java
+++ b/reactivesocket-client/src/test/java/io/reactivesocket/client/LoadBalancerTest.java
@@ -134,7 +134,7 @@ public class LoadBalancerTest {
     }
 
     private static ReactiveSocketClient succeedingFactory(ReactiveSocket socket) {
-        return new ReactiveSocketClient() {
+        return new AbstractReactiveSocketClient() {
             @Override
             public Publisher<ReactiveSocket> connect() {
                 return s -> s.onNext(socket);
@@ -149,7 +149,7 @@ public class LoadBalancerTest {
     }
 
     private static ReactiveSocketClient failingClient(SocketAddress sa) {
-        return new ReactiveSocketClient() {
+        return new AbstractReactiveSocketClient() {
             @Override
             public Publisher<ReactiveSocket> connect() {
                 Assert.fail();

--- a/reactivesocket-core/src/main/java/io/reactivesocket/client/AbstractReactiveSocketClient.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/client/AbstractReactiveSocketClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.client;
+
+import io.reactivesocket.events.AbstractEventSource;
+import io.reactivesocket.events.ClientEventListener;
+import io.reactivesocket.events.EventSource;
+
+public abstract class AbstractReactiveSocketClient extends AbstractEventSource<ClientEventListener>
+        implements ReactiveSocketClient{
+
+    protected AbstractReactiveSocketClient() {
+    }
+
+    protected AbstractReactiveSocketClient(EventSource<ClientEventListener> delegate) {
+        super(delegate);
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/client/ReactiveSocketClient.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/client/ReactiveSocketClient.java
@@ -19,12 +19,14 @@ package io.reactivesocket.client;
 import io.reactivesocket.AbstractReactiveSocket;
 import io.reactivesocket.Availability;
 import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.events.ClientEventListener;
+import io.reactivesocket.events.EventSource;
 import io.reactivesocket.lease.DisabledLeaseAcceptingSocket;
 import io.reactivesocket.lease.LeaseEnforcingSocket;
 import io.reactivesocket.transport.TransportClient;
 import org.reactivestreams.Publisher;
 
-public interface ReactiveSocketClient extends Availability {
+public interface ReactiveSocketClient extends Availability, EventSource<ClientEventListener> {
 
     /**
      * Creates a new {@code ReactiveSocket} every time the returned {@code Publisher} is subscribed.

--- a/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProvider.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProvider.java
@@ -18,6 +18,8 @@ package io.reactivesocket.client;
 
 import io.reactivesocket.Payload;
 import io.reactivesocket.client.ReactiveSocketClient.SocketAcceptor;
+import io.reactivesocket.events.ClientEventListener;
+import io.reactivesocket.events.EventSource;
 import io.reactivesocket.lease.DefaultLeaseHonoringSocket;
 import io.reactivesocket.DuplexConnection;
 import io.reactivesocket.Frame;
@@ -34,7 +36,7 @@ import java.util.function.Function;
 /**
  * A provider for ReactiveSocket setup from a client.
  */
-public interface SetupProvider {
+public interface SetupProvider extends EventSource<ClientEventListener> {
 
     int DEFAULT_FLAGS = SetupFrameFlyweight.FLAGS_WILL_HONOR_LEASE | SetupFrameFlyweight.FLAGS_STRICT_INTERPRETATION;
     int DEFAULT_MAX_KEEP_ALIVE_MISSING_ACK = 3;

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/AbstractEventSource.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/AbstractEventSource.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+import io.reactivesocket.internal.DisabledEventPublisher;
+import io.reactivesocket.internal.EventPublisher;
+import io.reactivesocket.internal.EventPublisherImpl;
+
+public abstract class AbstractEventSource<T extends EventListener> implements EventSource<T>, EventPublisher<T> {
+
+    private final EventSource<T> delegate;
+    private volatile EventPublisher<T> eventPublisher;
+
+    protected AbstractEventSource() {
+        eventPublisher = new DisabledEventPublisher<>();
+        delegate = new DisabledEventSource<>();
+    }
+
+    protected AbstractEventSource(EventSource<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean isEventPublishingEnabled() {
+        return eventPublisher.isEventPublishingEnabled();
+    }
+
+    @Override
+    public EventSubscription subscribe(T listener) {
+        EventPublisher<T> oldPublisher = null;
+        synchronized (this) {
+            if (eventPublisher != null) {
+                oldPublisher = eventPublisher;
+            }
+            eventPublisher = new EventPublisherImpl<>(listener);
+        }
+        EventSubscription delegateSubscription = delegate.subscribe(listener);
+        if (oldPublisher != null) {
+            // Dispose old listener and use the new one.
+            oldPublisher.cancel();
+        }
+        return new EventSubscription() {
+            @Override
+            public void cancel() {
+                eventPublisher.cancel();
+                delegateSubscription.cancel();
+                synchronized (AbstractEventSource.this) {
+                    if (eventPublisher == listener) {
+                        eventPublisher = null;
+                    }
+                }
+            }
+        };
+    }
+
+    @Override
+    public T getEventListener() {
+        return eventPublisher.getEventListener();
+    }
+
+    @Override
+    public void cancel() {
+        eventPublisher.cancel();
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/ClientEventListener.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/ClientEventListener.java
@@ -43,4 +43,12 @@ public interface ClientEventListener extends EventListener {
      * @param cause Cause for the failure.
      */
     default void connectFailed(long duration, TimeUnit durationUnit, Throwable cause) {}
+
+    /**
+     * Event when a connection attempt is cancelled.
+     *
+     * @param duration Time taken since connection initiation and cancellation.
+     * @param durationUnit {@code TimeUnit} for the duration.
+     */
+    default void connectCancelled(long duration, TimeUnit durationUnit) {}
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/ConnectionEventInterceptor.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/ConnectionEventInterceptor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+import io.reactivesocket.DuplexConnection;
+import io.reactivesocket.Frame;
+import io.reactivesocket.events.EventListener.RequestType;
+import io.reactivesocket.internal.EventPublisher;
+import io.reactivesocket.reactivestreams.extensions.Px;
+import io.reactivesocket.reactivestreams.extensions.internal.subscribers.Subscribers;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.LongSupplier;
+
+import static java.util.concurrent.TimeUnit.*;
+
+public final class ConnectionEventInterceptor implements DuplexConnection {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConnectionEventInterceptor.class);
+
+    private final DuplexConnection delegate;
+    private final EventPublisher<? extends EventListener> publisher;
+
+    public ConnectionEventInterceptor(DuplexConnection delegate, EventPublisher<? extends EventListener> publisher) {
+        this.delegate = delegate;
+        this.publisher = publisher;
+    }
+
+    @Override
+    public Publisher<Void> send(Publisher<Frame> frame) {
+        return delegate.send(Px.from(frame)
+                               .map(f -> {
+                                   try {
+                                       publishEventsForFrameWrite(f);
+                                   } catch (Exception e) {
+                                       logger.info("Error while emitting events for frame " + f
+                                                   + " written. Ignoring error.", e);
+                                   }
+                                   return f;
+                               }));
+    }
+
+    @Override
+    public Publisher<Void> sendOne(Frame frame) {
+        return delegate.sendOne(frame);
+    }
+
+    @Override
+    public Publisher<Frame> receive() {
+        return Px.from(delegate.receive())
+                 .map(f -> {
+                     try {
+                         publishEventsForFrameRead(f);
+                     } catch (Exception e) {
+                         logger.info("Error while emitting events for frame " + f + " read. Ignoring error.", e);
+                     }
+                     return f;
+                 });
+    }
+
+    @Override
+    public double availability() {
+        return delegate.availability();
+    }
+
+    @Override
+    public Publisher<Void> close() {
+        return delegate.close();
+    }
+
+    @Override
+    public Publisher<Void> onClose() {
+        return delegate.onClose();
+    }
+
+    private void publishEventsForFrameRead(Frame frameRead) {
+        if (!publisher.isEventPublishingEnabled()) {
+            return;
+        }
+        final EventListener listener = publisher.getEventListener();
+        listener.frameRead(frameRead.getStreamId(), frameRead.getType());
+
+        switch (frameRead.getType()) {
+        case LEASE:
+            listener.leaseReceived(Frame.Lease.numberOfRequests(frameRead), Frame.Lease.ttl(frameRead));
+            break;
+        case ERROR:
+            listener.errorReceived(frameRead.getStreamId(), Frame.Error.errorCode(frameRead));
+            break;
+        }
+    }
+
+    private void publishEventsForFrameWrite(Frame frameWritten) {
+        if (!publisher.isEventPublishingEnabled()) {
+            return;
+        }
+        final EventListener listener = publisher.getEventListener();
+        listener.frameWritten(frameWritten.getStreamId(), frameWritten.getType());
+
+        switch (frameWritten.getType()) {
+        case LEASE:
+            listener.leaseSent(Frame.Lease.numberOfRequests(frameWritten), Frame.Lease.ttl(frameWritten));
+            break;
+        case ERROR:
+            listener.errorSent(frameWritten.getStreamId(), Frame.Error.errorCode(frameWritten));
+            break;
+        }
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/DisabledEventSource.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/DisabledEventSource.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+public class DisabledEventSource<T extends EventListener> implements EventSource<T> {
+
+    @Override
+    public EventSubscription subscribe(T listener) {
+        return EmptySubscription.INSTANCE;
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/EmptySubscription.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/EmptySubscription.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+import io.reactivesocket.events.EventSource.EventSubscription;
+
+public final class EmptySubscription implements EventSubscription {
+
+    public static final EmptySubscription INSTANCE = new EmptySubscription();
+
+    private EmptySubscription() {
+        // No instances.
+    }
+
+    @Override
+    public void cancel() {
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/EventPublishingSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/EventPublishingSocket.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+import io.reactivesocket.events.EventListener.RequestType;
+import org.reactivestreams.Publisher;
+
+public interface EventPublishingSocket {
+
+    EventPublishingSocket DISABLED = new EventPublishingSocket() {
+        @Override
+        public <T> Publisher<T> decorateReceive(int streamId, Publisher<T> stream, RequestType requestType) {
+            return stream;
+        }
+
+        @Override
+        public <T> Publisher<T> decorateSend(int streamId, Publisher<T> stream, long receiveStartTimeNanos,
+                                             RequestType requestType) {
+            return stream;
+        }
+    };
+
+    <T> Publisher<T> decorateReceive(int streamId, Publisher<T> stream, RequestType requestType);
+
+    <T> Publisher<T> decorateSend(int streamId, Publisher<T> stream, long receiveStartTimeNanos,
+                                  RequestType requestType);
+
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/EventPublishingSocketImpl.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/EventPublishingSocketImpl.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+import io.reactivesocket.events.EventListener.RequestType;
+import io.reactivesocket.internal.EventPublisher;
+import io.reactivesocket.reactivestreams.extensions.internal.publishers.InstrumentingPublisher;
+import io.reactivesocket.util.Clock;
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.TimeUnit;
+
+public class EventPublishingSocketImpl implements EventPublishingSocket {
+
+    private final EventPublisher<? extends EventListener> eventPublisher;
+    private final boolean client;
+
+    public EventPublishingSocketImpl(EventPublisher<? extends EventListener> eventPublisher, boolean client) {
+        this.eventPublisher = eventPublisher;
+        this.client = client;
+    }
+
+    @Override
+    public <T> Publisher<T> decorateReceive(int streamId, Publisher<T> stream, RequestType requestType) {
+        final long startTime = Clock.now();
+        return new InstrumentingPublisher<>(stream,
+                                            subscriber -> new ReceiveInterceptor(streamId, requestType, startTime),
+                                            ReceiveInterceptor::receiveFailed, ReceiveInterceptor::receiveComplete,
+                                            ReceiveInterceptor::receiveCancelled, null);
+    }
+
+    @Override
+    public <T> Publisher<T> decorateSend(int streamId, Publisher<T> stream, long receiveStartTimeNanos,
+                                         RequestType requestType) {
+        return new InstrumentingPublisher<>(stream,
+                                            subscriber -> new SendInterceptor(streamId, requestType,
+                                                                              receiveStartTimeNanos),
+                                            SendInterceptor::sendFailed, SendInterceptor::sendComplete,
+                                            SendInterceptor::sendCancelled, null);
+    }
+
+    private class ReceiveInterceptor {
+
+        private final long startTime;
+        private final RequestType requestType;
+        private final int streamId;
+
+        public ReceiveInterceptor(int streamId, RequestType requestType, long startTime) {
+            this.streamId = streamId;
+            this.startTime = startTime;
+            this.requestType = requestType;
+            if (eventPublisher.isEventPublishingEnabled()) {
+                EventListener eventListener = eventPublisher.getEventListener();
+                if (client) {
+                    eventListener.responseReceiveStart(streamId, requestType, Clock.elapsedSince(startTime),
+                                                       Clock.unit());
+                } else {
+                    eventListener.requestReceiveStart(streamId, requestType);
+                }
+            }
+        }
+
+        public void receiveComplete() {
+            if (eventPublisher.isEventPublishingEnabled()) {
+                EventListener eventListener = eventPublisher.getEventListener();
+                if (client) {
+                    eventListener
+                            .responseReceiveComplete(streamId, requestType, Clock.elapsedSince(startTime),
+                                                     Clock.unit());
+                } else {
+                    eventListener
+                            .requestReceiveComplete(streamId, requestType, Clock.elapsedSince(startTime), Clock.unit());
+                }
+            }
+        }
+
+        public void receiveFailed(Throwable cause) {
+            if (eventPublisher.isEventPublishingEnabled()) {
+                EventListener eventListener = eventPublisher.getEventListener();
+                if (client) {
+                    eventListener.responseReceiveFailed(streamId, requestType,
+                                                        Clock.elapsedSince(startTime), Clock.unit(), cause);
+                } else {
+                    eventListener.requestReceiveFailed(streamId, requestType,
+                                                       Clock.elapsedSince(startTime), Clock.unit(), cause);
+                }
+            }
+        }
+
+        public void receiveCancelled() {
+            if (eventPublisher.isEventPublishingEnabled()) {
+                EventListener eventListener = eventPublisher.getEventListener();
+                if (client) {
+                    eventListener.responseReceiveCancelled(streamId, requestType,
+                                                           Clock.elapsedSince(startTime), Clock.unit());
+                } else {
+                    eventListener.requestReceiveCancelled(streamId, requestType,
+                                                          Clock.elapsedSince(startTime), Clock.unit());
+                }
+            }
+        }
+    }
+
+    private class SendInterceptor {
+
+        private final long startTime;
+        private final RequestType requestType;
+        private final int streamId;
+
+        public SendInterceptor(int streamId, RequestType requestType, long receiveStartTimeNanos) {
+            this.streamId = streamId;
+            startTime = Clock.now();
+            this.requestType = requestType;
+            if (eventPublisher.isEventPublishingEnabled()) {
+                EventListener eventListener = eventPublisher.getEventListener();
+                if (client) {
+                    eventListener.requestSendStart(streamId, requestType);
+                } else {
+                    eventListener.responseSendStart(streamId, requestType, Clock.elapsedSince(receiveStartTimeNanos),
+                                                    TimeUnit.NANOSECONDS);
+                }
+            }
+        }
+
+        public void sendComplete() {
+            if (eventPublisher.isEventPublishingEnabled()) {
+                EventListener eventListener = eventPublisher.getEventListener();
+                if (client) {
+                    eventListener
+                            .requestSendComplete(streamId, requestType, Clock.elapsedSince(startTime), Clock.unit());
+                } else {
+                    eventListener
+                            .responseSendComplete(streamId, requestType, Clock.elapsedSince(startTime), Clock.unit());
+                }
+            }
+        }
+
+        public void sendFailed(Throwable cause) {
+            if (eventPublisher.isEventPublishingEnabled()) {
+                EventListener eventListener = eventPublisher.getEventListener();
+                if (client) {
+                    eventListener.requestSendFailed(streamId, requestType, Clock.elapsedSince(startTime),
+                                                    Clock.unit(), cause);
+                } else {
+                    eventListener.responseSendFailed(streamId, requestType, Clock.elapsedSince(startTime), Clock.unit(),
+                                                     cause);
+                }
+            }
+        }
+
+        public void sendCancelled() {
+            if (eventPublisher.isEventPublishingEnabled()) {
+                EventListener eventListener = eventPublisher.getEventListener();
+                if (client) {
+                    eventListener.requestSendCancelled(streamId, requestType, Clock.elapsedSince(startTime),
+                                                       Clock.unit());
+                } else {
+                    eventListener.responseSendCancelled(streamId, requestType, Clock.elapsedSince(startTime),
+                                                        Clock.unit());
+                }
+            }
+        }
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/LoggingClientEventListener.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/LoggingClientEventListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+import org.slf4j.event.Level;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.DoubleSupplier;
+
+public class LoggingClientEventListener extends LoggingEventListener implements ClientEventListener {
+
+    public LoggingClientEventListener(String name, Level logLevel) {
+        super(name, logLevel);
+    }
+
+    @Override
+    public void connectStart() {
+        logIfEnabled(() -> name + ": connectStart");
+    }
+
+    @Override
+    public void connectCompleted(DoubleSupplier socketAvailabilitySupplier, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": connectCompleted " + "socketAvailabilitySupplier = [" + socketAvailabilitySupplier
+                           + "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void connectFailed(long duration, TimeUnit durationUnit, Throwable cause) {
+        logIfEnabled(() -> name + ": connectFailed " + "duration = [" + duration + "], durationUnit = [" +
+                           durationUnit + "], cause = [" + cause + ']');
+    }
+
+    @Override
+    public void connectCancelled(long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": connectCancelled " + "duration = [" + duration + "], durationUnit = [" +
+                           durationUnit + ']');
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/LoggingEventListener.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/LoggingEventListener.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+import io.reactivesocket.FrameType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class LoggingEventListener implements EventListener {
+
+    private final Logger logger;
+
+    protected final String name;
+    protected final Level logLevel;
+
+    public LoggingEventListener(String name, Level logLevel) {
+        this.name = name;
+        this.logLevel = logLevel;
+        logger = LoggerFactory.getLogger(name);
+    }
+
+    @Override
+    public void requestReceiveStart(int streamId, RequestType type) {
+        logIfEnabled(() -> name + ": requestReceiveStart " + "streamId = [" + streamId + "], type = [" + type + ']');
+    }
+
+    @Override
+    public void requestReceiveComplete(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": requestReceiveComplete " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void requestReceiveFailed(int streamId, RequestType type, long duration, TimeUnit durationUnit,
+                                     Throwable cause) {
+        logIfEnabled(() -> name + ": requestReceiveFailed " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + "], cause = ["
+                           + cause + ']');
+    }
+
+    @Override
+    public void requestReceiveCancelled(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": requestReceiveCancelled " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void requestSendStart(int streamId, RequestType type) {
+        logIfEnabled(() -> name + ": requestSendStart " + "streamId = [" + streamId + "], type = [" + type + ']');
+    }
+
+    @Override
+    public void requestSendComplete(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": requestSendComplete " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void requestSendFailed(int streamId, RequestType type, long duration, TimeUnit durationUnit,
+                                  Throwable cause) {
+        logIfEnabled(() -> name + ": requestSendFailed " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + "], cause = [" +
+                           cause + ']');
+    }
+
+    @Override
+    public void requestSendCancelled(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": requestSendCancelled " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void responseSendStart(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": responseSendStart " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void responseSendComplete(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": responseSendComplete " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void responseSendFailed(int streamId, RequestType type, long duration, TimeUnit durationUnit,
+                                   Throwable cause) {
+        System.out.println(name + ": responseSendFailed " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + "], cause = [" +
+                           cause + ']');
+    }
+
+    @Override
+    public void responseSendCancelled(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": responseSendCancelled " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void responseReceiveStart(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": responseReceiveStart " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void responseReceiveComplete(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": responseReceiveComplete " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void responseReceiveFailed(int streamId, RequestType type, long duration, TimeUnit durationUnit,
+                                      Throwable cause) {
+        logIfEnabled(() -> name + ": responseReceiveFailed " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + "], cause = [" +
+                           cause + ']');
+    }
+
+    @Override
+    public void responseReceiveCancelled(int streamId, RequestType type, long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": responseReceiveCancelled " + "streamId = [" + streamId + "], type = [" + type +
+                           "], duration = [" + duration + "], durationUnit = [" + durationUnit + ']');
+    }
+
+    @Override
+    public void socketClosed(long duration, TimeUnit durationUnit) {
+        logIfEnabled(() -> name + ": socketClosed " + "duration = [" + duration + "], durationUnit = [" +
+                           durationUnit + ']');
+    }
+
+    @Override
+    public void frameWritten(int streamId, FrameType frameType) {
+        logIfEnabled(() -> name + ": frameWritten " + "streamId = [" + streamId + "], frameType = [" + frameType + ']');
+    }
+
+    @Override
+    public void frameRead(int streamId, FrameType frameType) {
+        logIfEnabled(() -> name + ": frameRead " + "streamId = [" + streamId + "], frameType = [" + frameType + ']');
+    }
+
+    @Override
+    public void leaseSent(int permits, int ttl) {
+        logIfEnabled(() -> name + ": leaseSent " + "permits = [" + permits + "], ttl = [" + ttl + ']');
+    }
+
+    @Override
+    public void leaseReceived(int permits, int ttl) {
+        logIfEnabled(() -> name + ": leaseReceived " + "permits = [" + permits + "], ttl = [" + ttl + ']');
+    }
+
+    @Override
+    public void errorSent(int streamId, int errorCode) {
+        logIfEnabled(() -> name + ": errorSent " + "streamId = [" + streamId + "], errorCode = [" + errorCode + ']');
+    }
+
+    @Override
+    public void errorReceived(int streamId, int errorCode) {
+        logIfEnabled(() -> name + ": errorReceived " + "streamId = [" + streamId + "], errorCode = [" + errorCode + ']');
+    }
+
+    @Override
+    public void dispose() {
+        logIfEnabled(() -> name + ": dispose");
+    }
+
+    protected void logIfEnabled(Supplier<String> logMsgSupplier) {
+        switch (logLevel) {
+        case ERROR:
+            if (logger.isErrorEnabled()) {
+                logger.error(logMsgSupplier.get());
+            }
+            break;
+        case WARN:
+            if (logger.isWarnEnabled()) {
+                logger.warn(logMsgSupplier.get());
+            }
+            break;
+        case INFO:
+            if (logger.isInfoEnabled()) {
+                logger.info(logMsgSupplier.get());
+            }
+            break;
+        case DEBUG:
+            if (logger.isDebugEnabled()) {
+                logger.debug(logMsgSupplier.get());
+            }
+            break;
+        case TRACE:
+            if (logger.isTraceEnabled()) {
+                logger.trace(logMsgSupplier.get());
+            }
+            break;
+        }
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/LoggingServerEventListener.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/LoggingServerEventListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.events;
+
+import org.slf4j.event.Level;
+
+public class LoggingServerEventListener extends LoggingEventListener implements ServerEventListener {
+
+    public LoggingServerEventListener(String name, Level logLevel) {
+        super(name, logLevel);
+    }
+
+    @Override
+    public void socketAccepted() {
+        logIfEnabled(() -> name + ": socketAccepted ");
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/DisabledEventPublisher.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/DisabledEventPublisher.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.internal;
+
+import io.reactivesocket.events.EventListener;
+
+public class DisabledEventPublisher<T extends EventListener> extends EventPublisherImpl<T> {
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/EventPublisher.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/EventPublisher.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.internal;
+
+import io.reactivesocket.events.EventListener;
+import io.reactivesocket.events.EventSource.EventSubscription;
+
+public interface EventPublisher<T extends EventListener> extends EventSubscription {
+
+    /**
+     * @return {@link EventListener} associated with this publisher. Maybe {@code null} if event publishing disabled.
+     */
+    T getEventListener();
+
+    /**
+     * @return {@code true} if event publishing is enabled.
+     */
+    default boolean isEventPublishingEnabled() {
+        return false;
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/internal/EventPublisherImpl.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/internal/EventPublisherImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.internal;
+
+import io.reactivesocket.events.EventListener;
+
+public class EventPublisherImpl<T extends EventListener> implements EventPublisher<T> {
+
+    private final T listener;
+    private volatile boolean enabled;
+
+    protected EventPublisherImpl() {
+        listener = null;
+        enabled = false;
+    }
+
+    public EventPublisherImpl(T listener) {
+        this.listener = listener;
+        enabled = true;
+    }
+
+    @Override
+    public T getEventListener() {
+        return listener;
+    }
+
+    @Override
+    public boolean isEventPublishingEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public void cancel() {
+        enabled = false;
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/server/DefaultReactiveSocketServer.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/server/DefaultReactiveSocketServer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.server;
+
+import io.reactivesocket.ClientReactiveSocket;
+import io.reactivesocket.ConnectionSetupPayload;
+import io.reactivesocket.DuplexConnection;
+import io.reactivesocket.FrameType;
+import io.reactivesocket.ServerReactiveSocket;
+import io.reactivesocket.StreamIdSupplier;
+import io.reactivesocket.client.KeepAliveProvider;
+import io.reactivesocket.events.AbstractEventSource;
+import io.reactivesocket.events.ConnectionEventInterceptor;
+import io.reactivesocket.events.ServerEventListener;
+import io.reactivesocket.internal.ClientServerInputMultiplexer;
+import io.reactivesocket.lease.DefaultLeaseHonoringSocket;
+import io.reactivesocket.lease.LeaseEnforcingSocket;
+import io.reactivesocket.lease.LeaseHonoringSocket;
+import io.reactivesocket.reactivestreams.extensions.Px;
+import io.reactivesocket.reactivestreams.extensions.internal.subscribers.Subscribers;
+import io.reactivesocket.transport.TransportServer;
+import io.reactivesocket.transport.TransportServer.StartedServer;
+import io.reactivesocket.util.Clock;
+
+public final class DefaultReactiveSocketServer extends AbstractEventSource<ServerEventListener>
+        implements ReactiveSocketServer {
+
+    private final TransportServer transportServer;
+
+    public DefaultReactiveSocketServer(TransportServer transportServer) {
+        this.transportServer = transportServer;
+    }
+
+    @Override
+    public StartedServer start(SocketAcceptor acceptor) {
+        return transportServer.start(connection -> {
+            DuplexConnection dc;
+            if (isEventPublishingEnabled()) {
+                long startTime = Clock.now();
+                dc = new ConnectionEventInterceptor(connection, this);
+                getEventListener().socketAccepted();
+                dc.onClose()
+                  .subscribe(Subscribers.doOnTerminate(() -> {
+                      if (isEventPublishingEnabled()) {
+                          getEventListener().socketClosed(Clock.elapsedSince(startTime), Clock.unit());
+                      }
+                  }));
+            } else {
+                dc = connection;
+            }
+
+            return Px.from(dc.receive())
+                     .switchTo(setupFrame -> {
+                         if (setupFrame.getType() == FrameType.SETUP) {
+                             ClientServerInputMultiplexer multiplexer = new ClientServerInputMultiplexer(dc);
+                             ConnectionSetupPayload setup = ConnectionSetupPayload.create(setupFrame);
+                             ClientReactiveSocket sender = new ClientReactiveSocket(multiplexer.asServerConnection(),
+                                                                                    Throwable::printStackTrace,
+                                                                                    StreamIdSupplier.serverSupplier(),
+                                                                                    KeepAliveProvider.never(),
+                                                                                    this);
+                             LeaseHonoringSocket lhs = new DefaultLeaseHonoringSocket(sender);
+                             sender.start(lhs);
+                             LeaseEnforcingSocket handler = acceptor.accept(setup, sender);
+                             ServerReactiveSocket receiver = new ServerReactiveSocket(multiplexer.asClientConnection(),
+                                                                                      handler,
+                                                                                      setup.willClientHonorLease(),
+                                                                                      Throwable::printStackTrace,
+                                                                                      this);
+                             receiver.start();
+                             return dc.onClose();
+                         } else {
+                             return Px.<Void>error(new IllegalStateException("Invalid first frame on the connection: "
+                                                                             + dc + ", frame type received: "
+                                                                             + setupFrame.getType()));
+                         }
+                     });
+        });
+    }
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/server/ReactiveSocketServer.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/server/ReactiveSocketServer.java
@@ -16,23 +16,16 @@
 
 package io.reactivesocket.server;
 
-import io.reactivesocket.ClientReactiveSocket;
 import io.reactivesocket.ConnectionSetupPayload;
-import io.reactivesocket.FrameType;
 import io.reactivesocket.ReactiveSocket;
-import io.reactivesocket.ServerReactiveSocket;
-import io.reactivesocket.StreamIdSupplier;
-import io.reactivesocket.client.KeepAliveProvider;
+import io.reactivesocket.events.EventSource;
+import io.reactivesocket.events.ServerEventListener;
 import io.reactivesocket.exceptions.SetupException;
-import io.reactivesocket.internal.ClientServerInputMultiplexer;
-import io.reactivesocket.lease.DefaultLeaseHonoringSocket;
 import io.reactivesocket.lease.LeaseEnforcingSocket;
-import io.reactivesocket.lease.LeaseHonoringSocket;
-import io.reactivesocket.reactivestreams.extensions.Px;
 import io.reactivesocket.transport.TransportServer;
 import io.reactivesocket.transport.TransportServer.StartedServer;
 
-public interface ReactiveSocketServer {
+public interface ReactiveSocketServer extends EventSource<ServerEventListener> {
 
     /**
      * Starts this server.
@@ -44,34 +37,7 @@ public interface ReactiveSocketServer {
     StartedServer start(SocketAcceptor acceptor);
 
     static ReactiveSocketServer create(TransportServer transportServer) {
-        return acceptor -> {
-            return transportServer.start(connection -> {
-                return Px.from(connection.receive())
-                  .switchTo(setupFrame -> {
-                      if (setupFrame.getType() == FrameType.SETUP) {
-                          ClientServerInputMultiplexer multiplexer = new ClientServerInputMultiplexer(connection);
-                          ConnectionSetupPayload setupPayload = ConnectionSetupPayload.create(setupFrame);
-                          ClientReactiveSocket sender = new ClientReactiveSocket(multiplexer.asServerConnection(),
-                                                                                 Throwable::printStackTrace,
-                                                                                 StreamIdSupplier.serverSupplier(),
-                                                                                 KeepAliveProvider.never());
-                          LeaseHonoringSocket lhs = new DefaultLeaseHonoringSocket(sender);
-                          sender.start(lhs);
-                          LeaseEnforcingSocket handler = acceptor.accept(setupPayload, sender);
-                          ServerReactiveSocket receiver = new ServerReactiveSocket(multiplexer.asClientConnection(),
-                                                                                   handler,
-                                                                                   setupPayload.willClientHonorLease(),
-                                                                                   Throwable::printStackTrace);
-                          receiver.start();
-                          return connection.onClose();
-                      } else {
-                          return Px.<Void>error(new IllegalStateException("Invalid first frame on the connection: "
-                                                                          + connection + ", frame type received: "
-                                                                          + setupFrame.getType()));
-                      }
-                  });
-            });
-        };
+        return new DefaultReactiveSocketServer(transportServer);
     }
 
     /**

--- a/reactivesocket-core/src/main/java/io/reactivesocket/util/Clock.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/util/Clock.java
@@ -17,6 +17,9 @@ package io.reactivesocket.util;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Abstraction to get current time and durations.
+ */
 public final class Clock {
 
     private Clock() {

--- a/reactivesocket-examples/src/main/resources/log4j.properties
+++ b/reactivesocket-examples/src/main/resources/log4j.properties
@@ -17,4 +17,4 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] (%F:%L) - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] - %m%n

--- a/reactivesocket-publishers/src/main/java/io/reactivesocket/reactivestreams/extensions/internal/publishers/InstrumentingPublisher.java
+++ b/reactivesocket-publishers/src/main/java/io/reactivesocket/reactivestreams/extensions/internal/publishers/InstrumentingPublisher.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivesocket.reactivestreams.extensions.internal.publishers;
+
+import io.reactivesocket.reactivestreams.extensions.Px;
+import io.reactivesocket.reactivestreams.extensions.Scheduler;
+import io.reactivesocket.reactivestreams.extensions.internal.subscribers.CancellableSubscriber;
+import io.reactivesocket.reactivestreams.extensions.internal.subscribers.Subscribers;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A {@link Px} instance that facilitates usecases that involve creating a state on subscription and using it for all
+ * subsequent callbacks. eg: Capturing timings from subscription to termination.
+ *
+ * @param <T> Type of objects emitted by the publisher.
+ * @param <X> State to be created on subscription.
+ */
+public final class InstrumentingPublisher<T, X> implements Px<T> {
+
+    private final Publisher<T> source;
+    private final Function<Subscriber<? super T>, X> stateFactory;
+    private final BiConsumer<X, Throwable> onError;
+    private final Consumer<X> onComplete;
+    private final Consumer<X> onCancel;
+    private final BiConsumer<X, T> onNext;
+
+    public InstrumentingPublisher(Publisher<T> source, Function<Subscriber<? super T>, X> stateFactory,
+                                  BiConsumer<X, Throwable> onError, Consumer<X> onComplete, Consumer<X> onCancel,
+                                  BiConsumer<X, T> onNext) {
+        this.source = source;
+        this.stateFactory = stateFactory;
+        this.onError = onError;
+        this.onComplete = onComplete;
+        this.onCancel = onCancel;
+        this.onNext = onNext;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber) {
+        source.subscribe(new Subscriber<T>() {
+
+            private volatile X state;
+            private volatile boolean emit = true;
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                state = stateFactory.apply(subscriber);
+                if (null != onCancel) {
+                    subscriber.onSubscribe(new Subscription() {
+                        @Override
+                        public void request(long n) {
+                            s.request(n);
+                        }
+
+                        @Override
+                        public void cancel() {
+                            if (emit) {
+                                onCancel.accept(state);
+                            }
+                            emit = false;
+                            s.cancel();
+                        }
+                    });
+                } else {
+                    subscriber.onSubscribe(s);
+                }
+            }
+
+            @Override
+            public void onNext(T t) {
+                if (emit && null != onNext) {
+                    onNext.accept(state, t);
+                }
+                subscriber.onNext(t);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                if (emit && null != onError) {
+                    onError.accept(state, t);
+                }
+                emit = false;
+                subscriber.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                if (emit && null != onComplete) {
+                    onComplete.accept(state);
+                }
+                emit = false;
+                subscriber.onComplete();
+            }
+        });
+    }
+}


### PR DESCRIPTION
__Problem__

No events are published for `ReactiveSocketClient` and `ReactiveSocketServer`

__Modification__

Added event publishing for `ReactiveSocketClient` and `ReactiveSocketServer`

__Result__

Events for clients and servers.

PS: This does not yet add events for `LoadBalancer`. I will send a separate PR for that.