### PR TITLE
fails on requestSubscription calls

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/events/EventListener.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/events/EventListener.java
@@ -33,6 +33,7 @@ public interface EventListener {
     enum RequestType {
         RequestResponse,
         RequestStream,
+        RequestSubscription,
         RequestChannel,
         MetadataPush,
         FireAndForget;
@@ -45,6 +46,8 @@ public interface EventListener {
                 return FireAndForget;
             case REQUEST_STREAM:
                 return RequestStream;
+            case REQUEST_SUBSCRIPTION:
+                return RequestSubscription;
             case REQUEST_CHANNEL:
                 return RequestChannel;
             case METADATA_PUSH:


### PR DESCRIPTION
We haven't yet killed off requestSubscription and the Frame type constants still include it, so I'd expect this to work for now.