### PR TITLE
added pid lease controller

### DIFF
--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/DefaultPid.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/DefaultPid.java
@@ -1,0 +1,7 @@
+package io.reactivesocket.server.leases;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class DefaultPid {
+}

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/DefaultPid.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/DefaultPid.java
@@ -1,7 +1,69 @@
 package io.reactivesocket.server.leases;
 
+import java.util.concurrent.TimeUnit;
+import java.util.function.DoubleSupplier;
+
 /**
- * Created by rroeser on 1/12/17.
+ * PID controller implementation that is thread-safe. It uses {@code java.util.function.DoubleConsumer} functional
+ * interfaces to supply the setpoint and kP, kI, and kD values. This allows the Pid controller to be dynamic.
+ *
  */
-public class DefaultPid {
+public class DefaultPid implements Pid {
+    private DoubleSupplier kP;
+    private DoubleSupplier kI;
+    private DoubleSupplier kD;
+    private DoubleSupplier setpoint;
+
+    private double errorSum;
+    private double lastError;
+    private double output;
+    private long lastUpdateTs;
+
+    public DefaultPid(DoubleSupplier setpoint, DoubleSupplier kP, DoubleSupplier kI, DoubleSupplier kD) {
+        this.setpoint = setpoint;
+        this.kP = kP;
+        this.kI = kI;
+        this.kD = kD;
+        this.lastUpdateTs = System.currentTimeMillis();
+    }
+
+    public synchronized double update(double processValue) {
+        long now = System.currentTimeMillis();
+        long dt = TimeUnit.MILLISECONDS.toSeconds(now - lastUpdateTs);
+
+        if (dt < 1) {
+            dt = 1;
+        }
+
+        double error = setpoint.getAsDouble() - processValue;
+        double p = kP.getAsDouble() * error;
+
+        errorSum  = errorSum + error * dt;
+        double i = kI.getAsDouble() * errorSum;
+
+        double dError = (error - lastError) / dt;
+        double d = kD.getAsDouble() * dError;
+
+        output = p + limit(i) + limit(d);
+
+        lastError = error;
+
+        lastUpdateTs = now;
+
+        return output;
+    }
+
+    public synchronized double getOutput() {
+        return output;
+    }
+
+    double limit(double d) {
+        if (d > 5.0) {
+            return 5.0;
+        } else if (d < -5.0) {
+            return -5.0;
+        }
+
+        return d;
+    }
 }

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/DynamicSetpoint.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/DynamicSetpoint.java
@@ -1,7 +1,78 @@
 package io.reactivesocket.server.leases;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.DoubleConsumer;
+import java.util.function.DoubleSupplier;
+import java.util.function.LongSupplier;
+
 /**
- * Created by rroeser on 1/12/17.
+ * Calculates a setpoint by using the sign of the derivative of the different between outstanding and processed counters.
+ * If the derivative is 0 or greater it will add one to the setpoint, otherwise it subtract one until it reeaches
+ * zero again.
  */
-public class DynamicSetpoint {
+public class DynamicSetpoint implements DoubleSupplier {
+    private static final Logger logger = LoggerFactory.getLogger(DynamicSetpoint.class);
+    private final LongSupplier outstanding;
+    private final LongSupplier processed;
+    private final DoubleConsumer onCalculateSetpoint;
+    private final DoubleConsumer onCalculateDerivative;
+    private double setpoint;
+    private double lastDerivative;
+    private long lastUpdateTs;
+    private long lastOutstanding;
+    private long lastProcessed;
+
+    public DynamicSetpoint(LongSupplier outstanding, LongSupplier processed, DoubleConsumer onCalculateSetpoint, DoubleConsumer onCalculateDerivative) {
+        this.outstanding = outstanding;
+        this.processed = processed;
+        this.lastUpdateTs = System.currentTimeMillis();
+        this.onCalculateSetpoint = onCalculateSetpoint;
+        this.onCalculateDerivative = onCalculateDerivative;
+        this.setpoint = Runtime.getRuntime().availableProcessors() * 10;
+    }
+
+    public synchronized double calculateNewSetpoint() {
+        long now = System.nanoTime();
+        long dt = lastUpdateTs - now;
+        long currentOutstanding = outstanding.getAsLong();
+        long currentProcessed = processed.getAsLong();
+
+        if (dt < 1) {
+            dt = 1;
+        }
+
+        double diff = currentOutstanding - currentProcessed;
+        double derivative = (diff - lastDerivative) / dt;
+
+        if (onCalculateDerivative != null) {
+            onCalculateDerivative.accept(derivative);
+        }
+
+        if (derivative > 0) {
+            setpoint += 1;
+        } else if (derivative < 0) {
+            setpoint = Math.max(0, setpoint - 1);
+        }
+
+        if (onCalculateSetpoint != null) {
+            onCalculateSetpoint.accept(setpoint);
+        }
+
+        lastUpdateTs = now;
+        lastDerivative = derivative;
+        lastOutstanding = currentOutstanding;
+        lastProcessed = currentProcessed;
+
+        logger.debug("dynamic setpoint calculated: setpoint => {}, diff => {}, derivative => {}", setpoint, diff, derivative);
+
+        return setpoint;
+    }
+
+    @Override
+    public synchronized double getAsDouble() {
+        return setpoint;
+    }
+
 }

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/DynamicSetpoint.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/DynamicSetpoint.java
@@ -1,0 +1,7 @@
+package io.reactivesocket.server.leases;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class DynamicSetpoint {
+}

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/Pid.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/Pid.java
@@ -1,0 +1,7 @@
+package io.reactivesocket.server.leases;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class Pid {
+}

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/Pid.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/Pid.java
@@ -1,7 +1,16 @@
 package io.reactivesocket.server.leases;
 
-/**
- * Created by rroeser on 1/12/17.
- */
-public class Pid {
+public interface Pid {
+    /**
+     * Updates the PID with the new process value
+     * @param processValue the process value
+     * @return output calculated after update
+     */
+    double update(double processValue);
+
+    /**
+     * The current output
+     * @return PID controller output
+     */
+    double getOutput();
 }

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/PidCapacitySupplier.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/PidCapacitySupplier.java
@@ -1,0 +1,7 @@
+package io.reactivesocket.server.leases;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class PidCapacitySupplier {
+}

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/PidCapacitySupplier.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/PidCapacitySupplier.java
@@ -1,7 +1,184 @@
 package io.reactivesocket.server.leases;
 
+
+import io.reactivesocket.stat.Ewma;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.DoubleConsumer;
+import java.util.function.DoubleSupplier;
+import java.util.function.IntConsumer;
+import java.util.function.IntSupplier;
+
 /**
- * Created by rroeser on 1/12/17.
+ * Calculates leases using two pid controllers. One controller is used to calculate the number of leases needed to have
+ * zero {@link io.reactivesocket.exceptions.RejectedException}s. The other pid controller is used to control concurrency.
+ * The do not run at the same time. The rejection based pid controller runs when there are no pending requests. If there
+ * are pending requests the concurrency controller is used instead.
+ * <p>
+ * The control will also decay the number of leases if the current leases are 1.5 times greater than the estimated leases.
+ *
+ * @author Robert Roeser
  */
-public class PidCapacitySupplier {
+public class PidCapacitySupplier implements IntSupplier {
+    private static final Logger logger = LoggerFactory.getLogger(PidCapacitySupplier.class);
+
+    private final ReactiveSocketServerStats stats;
+
+    private final Pid rejectionPid;
+
+    private final Pid concurrencyPid;
+
+    private final DynamicSetpoint setpoint;
+
+    private double leases;
+
+    private double lastRejected;
+
+    private double lastProcessed;
+
+    private final IntConsumer onCalculateLease;
+
+    private final IntSupplier overrideLeases;
+
+    private final Ewma estimatedLeasesAvg;
+
+    public PidCapacitySupplier(
+        ReactiveSocketServerStats stats,
+        IntSupplier overrideLeases,
+        DoubleSupplier kP,
+        DoubleSupplier kI,
+        DoubleSupplier kD,
+        DoubleConsumer onCalculateSetpoint,
+        DoubleConsumer onCalculateDerivative,
+        IntConsumer onCalculateLease,
+        long ttlMillis) {
+        this(stats, overrideLeases, onCalculateSetpoint, onCalculateDerivative, onCalculateLease, kP, kI, kD, kP, kI, kD, ttlMillis);
+    }
+
+    public PidCapacitySupplier(ReactiveSocketServerStats stats,
+                                IntSupplier overrideLeases,
+                                DoubleConsumer onCalculateSetpoint,
+                                DoubleConsumer onCalculateDerivative,
+                                IntConsumer onCalculateLease,
+                                DoubleSupplier rejections_kP,
+                                DoubleSupplier rejections_kI,
+                                DoubleSupplier rejections_kD,
+                                DoubleSupplier concurrency_kP,
+                                DoubleSupplier concurrency_kI,
+                                DoubleSupplier concurrency_kD,
+                                long ttlMillis) {
+        this.onCalculateLease = onCalculateLease;
+        this.overrideLeases = overrideLeases;
+        this.stats = stats;
+        this.setpoint = new DynamicSetpoint(
+            stats::getCurrentOustanding,
+            stats::getCurrentProcessed,
+            onCalculateSetpoint,
+            onCalculateDerivative);
+
+        this.rejectionPid = new DefaultPid(() -> 0, rejections_kP, rejections_kI, rejections_kD);
+        this.concurrencyPid = new DefaultPid(setpoint, concurrency_kP, concurrency_kI, concurrency_kD);
+
+        this.leases = 1;
+        estimatedLeasesAvg = new Ewma(ttlMillis / 2, TimeUnit.MINUTES.toMillis(5), TimeUnit.MILLISECONDS, 0.0);
+    }
+
+    @Override
+    public synchronized int getAsInt() {
+        final double processed = stats.getCurrentProcessed();
+        final double rejected = stats.getCurrentRejected();
+
+        double currentEstimate = (processed - lastProcessed) * 1.5;
+        estimatedLeasesAvg.insert(currentEstimate);
+        double estimatedLeases = estimatedLeasesAvg.value();
+
+        logger.debug("current estimated leases => {}", estimatedLeases);
+
+        if (overrideLeases != null && overrideLeases.getAsInt() > 0) {
+            logger.debug("overriding leases => " + overrideLeases.getAsInt());
+            return overrideLeases.getAsInt();
+        }
+
+        boolean useConcurrency = calculateLeasesBasedOnConcurrency(processed);
+        if (!useConcurrency) {
+            logger.debug("zero pending requests, basing leases on rejects");
+            calculateLeasesBasedOnRejections(rejected, estimatedLeases);
+        }
+
+        lastProcessed = processed;
+        lastRejected = rejected;
+
+        int l = (int) Math.ceil(leases);
+        if (onCalculateLease != null) {
+            onCalculateLease.accept(l);
+        }
+
+        return l;
+    }
+
+    private boolean calculateLeasesBasedOnConcurrency(double processed) {
+        final double outstanding = stats.getCurrentOustanding();
+        final double pending = outstanding - processed;
+
+        final double currentSetpoint = setpoint.getAsDouble();
+        final double newSetpoint = setpoint.calculateNewSetpoint();
+
+        logger.debug("outstanding => {}, " +
+            "processed = > {}, " +
+            "pending => {}, " +
+            "current setpoint => {}, " +
+            "new setpoint => {}", outstanding, processed, pending, currentSetpoint, newSetpoint);
+
+        boolean useConcurrency = false;
+        if (pending > 0) {
+            useConcurrency = true;
+            double update = concurrencyPid.update(pending);
+            double oldLeases = leases;
+            leases += update;
+
+            logger.debug("using concurrency => true," +
+                " update => {}," +
+                " old leases => {}," +
+                " new leases => {}", update, oldLeases, leases);
+        }
+
+        return useConcurrency;
+    }
+
+    private void calculateLeasesBasedOnRejections(double rejected, double estimatedLeases) {
+        double processValue = lastRejected - rejected;
+        double update = rejectionPid.update(processValue);
+        double oldLeases = leases;
+
+        if (processValue < 0) {
+            logger.debug("process value was zero, not updating leases");
+            leases += update;
+        } else {
+            decay(estimatedLeases);
+        }
+
+        if (leases < 0) {
+            logger.debug("calculated leases less than zero => {}, setting to 1", leases);
+            leases = 1;
+        }
+
+        logger.debug("rejection pid: " +
+            "\nrejected => {}," +
+            "\nprocessValue => {}," +
+            "\nupdate => {}," +
+            "\nold leases => {}," +
+            "\nnew leases => {}", rejected, processValue, update, oldLeases, leases);
+
+    }
+
+    private void decay(double estimatedLeases) {
+        if (estimatedLeases > 0 && leases > estimatedLeases) {
+            double oldLeases = leases;
+            double diff = leases - estimatedLeases;
+            leases -= diff;
+            logger.debug("decaying - old leases => {}, diff => {}, leases => {}", oldLeases, diff, leases);
+        }
+    }
 }

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/ReactiveSocketServerStats.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/ReactiveSocketServerStats.java
@@ -1,0 +1,7 @@
+package io.reactivesocket.server.leases;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class ReactiveSocketServerStats {
+}

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/ReactiveSocketServerStats.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/ReactiveSocketServerStats.java
@@ -1,7 +1,52 @@
 package io.reactivesocket.server.leases;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
- * Created by rroeser on 1/12/17.
+ *
  */
 public class ReactiveSocketServerStats {
+    private AtomicLong outstanding;
+    private AtomicLong processed;
+    private AtomicLong successful;
+    private AtomicLong rejected;
+
+    public ReactiveSocketServerStats() {
+        outstanding = new AtomicLong();
+        processed = new AtomicLong();
+        successful = new AtomicLong();
+        rejected = new AtomicLong();
+    }
+
+    public void incrementOutstanding() {
+        outstanding.incrementAndGet();
+    }
+
+    public void incrementProcessed() {
+        processed.incrementAndGet();
+    }
+
+    public void incrementSuccessful() {
+        successful.incrementAndGet();
+    }
+
+    public void incrementRejected() {
+        rejected.incrementAndGet();
+    }
+
+    public long getCurrentOustanding() {
+        return outstanding.get();
+    }
+
+    public long getCurrentProcessed() {
+        return processed.get();
+    }
+
+    public long getCurrentSuccessful() {
+        return successful.get();
+    }
+
+    public long getCurrentRejected() {
+        return rejected.get();
+    }
 }

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/ServerStatsLeaseEnforcingSocket.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/ServerStatsLeaseEnforcingSocket.java
@@ -1,7 +1,130 @@
 package io.reactivesocket.server.leases;
 
+
+import io.reactivesocket.Payload;
+import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.exceptions.RejectedException;
+import io.reactivesocket.lease.DefaultLeaseEnforcingSocket;
+import io.reactivesocket.reactivestreams.extensions.Px;
+import org.reactivestreams.Publisher;
+
+import java.util.function.LongSupplier;
+
 /**
- * Created by rroeser on 1/12/17.
+ * Extends {@code DefautLeaseEnforcingSocket} and records stats that can be used to
+ * report, or adjust the leases.
  */
-public class ServerStatsLeaseEnforcingSocket {
+public class ServerStatsLeaseEnforcingSocket extends DefaultLeaseEnforcingSocket {
+    private final ReactiveSocketServerStats stats;
+
+    public ServerStatsLeaseEnforcingSocket(
+        ReactiveSocket delegate,
+        ReactiveSocketServerStats stats,
+        LeaseDistributor leaseDistributor,
+        LongSupplier currentTimeSupplier,
+        boolean clientHonorsLeases) {
+        super(delegate, leaseDistributor, currentTimeSupplier, clientHonorsLeases);
+        this.stats = stats;
+    }
+
+    public ServerStatsLeaseEnforcingSocket(
+        ReactiveSocket delegate,
+        ReactiveSocketServerStats stats,
+        LeaseDistributor leaseDistributor,
+        LongSupplier currentTimeSupplier) {
+        super(delegate, leaseDistributor, currentTimeSupplier);
+        this.stats = stats;
+    }
+
+    public ServerStatsLeaseEnforcingSocket(
+        ReactiveSocket delegate,
+        ReactiveSocketServerStats stats,
+        LeaseDistributor leaseDistributor) {
+        super(delegate, leaseDistributor);
+        this.stats = stats;
+    }
+
+    @Override
+    public Publisher<Void> fireAndForget(Payload payload) {
+        stats.incrementOutstanding();
+        return Px
+            .from(super.fireAndForget(payload))
+            .doOnError(t -> {
+                if (t instanceof RejectedException) {
+                    stats.incrementRejected();
+                }
+            })
+            .doOnComplete(stats::incrementSuccessful)
+            .doFinally(stats::incrementProcessed);
+    }
+
+    @Override
+    public Publisher<Payload> requestResponse(Payload payload) {
+        stats.incrementOutstanding();
+        return Px
+            .from(super.requestResponse(payload))
+            .doOnError(t -> {
+                if (t instanceof RejectedException) {
+                    stats.incrementRejected();
+                }
+            })
+            .doOnComplete(stats::incrementSuccessful)
+            .doFinally(stats::incrementProcessed);
+    }
+
+    @Override
+    public Publisher<Payload> requestStream(Payload payload) {
+        stats.incrementOutstanding();
+        return Px
+            .from(super.requestStream(payload))
+            .doOnError(t -> {
+                if (t instanceof RejectedException) {
+                    stats.incrementRejected();
+                }
+            })
+            .doOnComplete(stats::incrementSuccessful)
+            .doFinally(stats::incrementProcessed);
+    }
+
+    @Override
+    public Publisher<Payload> requestSubscription(Payload payload) {
+        stats.incrementOutstanding();
+        return Px
+            .from(super.requestSubscription(payload))
+            .doOnError(t -> {
+                if (t instanceof RejectedException) {
+                    stats.incrementRejected();
+                }
+            })
+            .doOnComplete(stats::incrementSuccessful)
+            .doFinally(stats::incrementProcessed);
+    }
+
+    @Override
+    public Publisher<Payload> requestChannel(Publisher<Payload> payloads) {
+        stats.incrementOutstanding();
+        return Px
+            .from(super.requestChannel(payloads))
+            .doOnError(t -> {
+                if (t instanceof RejectedException) {
+                    stats.incrementRejected();
+                }
+            })
+            .doOnComplete(stats::incrementSuccessful)
+            .doFinally(stats::incrementProcessed);
+    }
+
+    @Override
+    public Publisher<Void> metadataPush(Payload payload) {
+        stats.incrementOutstanding();
+        return Px
+            .from(super.metadataPush(payload))
+            .doOnError(t -> {
+                if (t instanceof RejectedException) {
+                    stats.incrementRejected();
+                }
+            })
+            .doOnComplete(stats::incrementSuccessful)
+            .doFinally(stats::incrementProcessed);
+    }
 }

--- a/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/ServerStatsLeaseEnforcingSocket.java
+++ b/reactivesocket-client/src/main/java/io/reactivesocket/server/leases/ServerStatsLeaseEnforcingSocket.java
@@ -1,0 +1,7 @@
+package io.reactivesocket.server.leases;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class ServerStatsLeaseEnforcingSocket {
+}

--- a/reactivesocket-client/src/test/java/io/reactivesocket/server/leases/DefaultPidTest.java
+++ b/reactivesocket-client/src/test/java/io/reactivesocket/server/leases/DefaultPidTest.java
@@ -1,8 +1,17 @@
-import static org.junit.Assert.*;
+package io.reactivesocket.server.leases;
 
-/**
- * Created by rroeser on 1/12/17.
- */
+import org.junit.Test;
+
 public class DefaultPidTest {
+    @Test
+    public void testPid() {
+        Pid pid = new DefaultPid(() -> 100, () -> 0.5, () -> 0.5, () -> 10);
 
+        System.out.println(pid.getOutput());
+
+        for (int i = 0; i < 200; i++) {
+            pid.update(i);
+            System.out.println(pid.getOutput());
+        }
+    }
 }

--- a/reactivesocket-client/src/test/java/io/reactivesocket/server/leases/DefaultPidTest.java
+++ b/reactivesocket-client/src/test/java/io/reactivesocket/server/leases/DefaultPidTest.java
@@ -1,0 +1,8 @@
+import static org.junit.Assert.*;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class DefaultPidTest {
+
+}

--- a/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProvider.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProvider.java
@@ -16,18 +16,18 @@
 
 package io.reactivesocket.client;
 
-import io.reactivesocket.Payload;
-import io.reactivesocket.client.ReactiveSocketClient.SocketAcceptor;
-import io.reactivesocket.events.ClientEventListener;
-import io.reactivesocket.events.EventSource;
-import io.reactivesocket.lease.DefaultLeaseHonoringSocket;
 import io.reactivesocket.DuplexConnection;
 import io.reactivesocket.Frame;
 import io.reactivesocket.Frame.Setup;
-import io.reactivesocket.lease.DisableLeaseSocket;
-import io.reactivesocket.lease.LeaseHonoringSocket;
+import io.reactivesocket.Payload;
 import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.client.ReactiveSocketClient.SocketAcceptor;
+import io.reactivesocket.events.ClientEventListener;
+import io.reactivesocket.events.EventSource;
 import io.reactivesocket.frame.SetupFrameFlyweight;
+import io.reactivesocket.lease.DisableLeaseSocket;
+import io.reactivesocket.lease.LeaseBasedAvailabilitySocket;
+import io.reactivesocket.lease.LeaseHonoringSocket;
 import io.reactivesocket.util.PayloadImpl;
 import org.reactivestreams.Publisher;
 
@@ -115,9 +115,9 @@ public interface SetupProvider extends EventSource<ClientEventListener> {
     static SetupProvider keepAlive(KeepAliveProvider keepAliveProvider) {
         int period = keepAliveProvider.getKeepAlivePeriodMillis();
         Frame setupFrame =
-                Setup.from(DEFAULT_FLAGS, period, keepAliveProvider.getMissedKeepAliveThreshold() * period,
-                           DEFAULT_METADATA_MIME_TYPE, DEFAULT_DATA_MIME_TYPE, PayloadImpl.EMPTY);
-        return new SetupProviderImpl(setupFrame, reactiveSocket -> new DefaultLeaseHonoringSocket(reactiveSocket),
-                                     keepAliveProvider, Throwable::printStackTrace);
+            Setup.from(DEFAULT_FLAGS, period, keepAliveProvider.getMissedKeepAliveThreshold() * period,
+                DEFAULT_METADATA_MIME_TYPE, DEFAULT_DATA_MIME_TYPE, PayloadImpl.EMPTY);
+        return new SetupProviderImpl(setupFrame, reactiveSocket -> new LeaseBasedAvailabilitySocket(reactiveSocket),
+            keepAliveProvider, Throwable::printStackTrace);
     }
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/lease/LeaseBasedAvailabilitySocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/lease/LeaseBasedAvailabilitySocket.java
@@ -1,7 +1,140 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.reactivesocket.lease;
 
+import io.reactivesocket.Payload;
+import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.reactivestreams.extensions.Px;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
- * Created by rroeser on 1/12/17.
+ * Doesn't reject the request when leases are zero, just lowers the availability to zero.
  */
-public class LeaseBasedAvailabilitySocket {
+public class LeaseBasedAvailabilitySocket implements LeaseHonoringSocket {
+
+    private static final Logger logger = LoggerFactory.getLogger(LeaseBasedAvailabilitySocket.class);
+
+    private volatile Lease currentLease;
+    private final ReactiveSocket delegate;
+    private final AtomicInteger remainingQuota;
+    private final AtomicInteger concurrency;
+    private volatile int concurrencyLimit = 0;
+
+    public LeaseBasedAvailabilitySocket(ReactiveSocket delegate) {
+        this.delegate = delegate;
+        this.remainingQuota = new AtomicInteger();
+        this.concurrency = new AtomicInteger();
+    }
+
+    @Override
+    public void accept(Lease lease) {
+        logger.debug("accepting lease allowed requests => {}, ttl => {}", lease.getAllowedRequests(), lease.getTtl());
+        currentLease = lease;
+        remainingQuota.set(lease.getAllowedRequests());
+
+        ByteBuffer metadata = lease.metadata();
+        if (metadata != null) {
+            metadata.rewind();
+            concurrencyLimit = metadata.getInt(0);
+        } else {
+            concurrencyLimit = Runtime.getRuntime().availableProcessors() * 10;
+        }
+    }
+
+    @Override
+    public Publisher<Void> fireAndForget(Payload payload) {
+        remainingQuota.decrementAndGet();
+        concurrency.incrementAndGet();
+        return Px.from(delegate.fireAndForget(payload)).doFinally(concurrency::decrementAndGet);
+    }
+
+    @Override
+    public Publisher<Payload> requestResponse(Payload payload) {
+        remainingQuota.decrementAndGet();
+        concurrency.incrementAndGet();
+        return Px.from(delegate.requestResponse(payload)).doFinally(concurrency::decrementAndGet);
+    }
+
+    @Override
+    public Publisher<Payload> requestStream(Payload payload) {
+        remainingQuota.decrementAndGet();
+        concurrency.incrementAndGet();
+        return Px.from(delegate.requestStream(payload)).doFinally(concurrency::decrementAndGet);
+    }
+
+    @Override
+    public Publisher<Payload> requestSubscription(Payload payload) {
+        remainingQuota.decrementAndGet();
+        concurrency.incrementAndGet();
+        return Px.from(delegate.requestSubscription(payload)).doFinally(concurrency::decrementAndGet);
+    }
+
+    @Override
+    public Publisher<Payload> requestChannel(Publisher<Payload> payloads) {
+        remainingQuota.decrementAndGet();
+        concurrency.incrementAndGet();
+        return Px.from(delegate.requestChannel(payloads)).doFinally(concurrency::decrementAndGet);
+    }
+
+    @Override
+    public Publisher<Void> metadataPush(Payload payload) {
+        remainingQuota.decrementAndGet();
+        concurrency.incrementAndGet();
+        return Px.from(delegate.metadataPush(payload)).doFinally(concurrency::decrementAndGet);
+    }
+
+    @Override
+    public double availability() {
+        if (currentLease == null || currentLease.getAllowedRequests() <= 0 || currentLease.isExpired()) {
+            return 0.0;
+        } else {
+            return
+                delegate.availability()
+                    * ((double) remainingQuota.get() / (double) currentLease.getAllowedRequests())
+                    * computeConcurrencyAvailability();
+        }
+    }
+
+    private double computeConcurrencyAvailability() {
+        double availability;
+        int currentLimit = concurrencyLimit;
+        if (currentLimit <= 0) {
+            availability = 0;
+        } else {
+            availability = Math.max((currentLimit - concurrency.get()), 0) / (double) currentLimit;
+        }
+
+        return availability;
+
+    }
+
+    @Override
+    public Publisher<Void> close() {
+        return delegate.close();
+    }
+
+    @Override
+    public Publisher<Void> onClose() {
+        return delegate.onClose();
+    }
+
 }

--- a/reactivesocket-core/src/main/java/io/reactivesocket/lease/LeaseBasedAvailabilitySocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/lease/LeaseBasedAvailabilitySocket.java
@@ -1,0 +1,7 @@
+package io.reactivesocket.lease;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class LeaseBasedAvailabilitySocket {
+}

--- a/reactivesocket-core/src/test/java/io/reactivesocket/client/SetupProviderImplTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/client/SetupProviderImplTest.java
@@ -49,7 +49,7 @@ public class SetupProviderImplTest {
 
         setupProvider = setupProvider.setupPayload(setupPayload);
         TestDuplexConnection connection = new TestDuplexConnection();
-        FairLeaseDistributor distributor = new FairLeaseDistributor(() -> 0, 0, Flowable.never());
+        FairLeaseDistributor distributor = new FairLeaseDistributor(() -> 0, () -> 0, Flowable.never());
         ReactiveSocket socket = Flowable.fromPublisher(setupProvider
                                                  .accept(connection,
                                                          reactiveSocket -> new DefaultLeaseEnforcingSocket(

--- a/reactivesocket-core/src/test/java/io/reactivesocket/lease/DefaultLeaseEnforcingSocketTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/lease/DefaultLeaseEnforcingSocketTest.java
@@ -86,7 +86,7 @@ public class DefaultLeaseEnforcingSocketTest extends DefaultLeaseTest<SocketHold
         public static SocketHolder newHolder(LongSupplier currentTimeSupplier, int permits, int ttl) {
             LongSupplier _currentTimeSupplier = null == currentTimeSupplier? () -> -1 : currentTimeSupplier;
             PublishProcessor<Long> leaseTicks = PublishProcessor.create();
-            FairLeaseDistributor distributor = new FairLeaseDistributor(() -> permits, ttl, leaseTicks);
+            FairLeaseDistributor distributor = new FairLeaseDistributor(() -> permits, () -> ttl, leaseTicks);
             AbstractSocketRule<DefaultLeaseEnforcingSocket> rule = new AbstractSocketRule<DefaultLeaseEnforcingSocket>() {
                 @Override
                 protected DefaultLeaseEnforcingSocket newSocket(ReactiveSocket delegate) {

--- a/reactivesocket-core/src/test/java/io/reactivesocket/lease/FairLeaseDistributorTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/lease/FairLeaseDistributorTest.java
@@ -117,7 +117,7 @@ public class FairLeaseDistributorTest {
             if (0 == ttl) {
                 ttl = 10;
             }
-            distributor = new FairLeaseDistributor(() -> permits, ttl, ticks, redistributeOnConnect);
+            distributor = new FairLeaseDistributor(() -> permits, () -> ttl, ticks, redistributeOnConnect);
             leases = new CopyOnWriteArrayList<>();
         }
 

--- a/reactivesocket-core/src/test/java/io/reactivesocket/lease/LeaseBasedAvailabilitySocketTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/lease/LeaseBasedAvailabilitySocketTest.java
@@ -1,0 +1,8 @@
+import static org.junit.Assert.*;
+
+/**
+ * Created by rroeser on 1/12/17.
+ */
+public class LeaseBasedAvailabilitySocketTest {
+
+}

--- a/reactivesocket-core/src/test/java/io/reactivesocket/lease/LeaseBasedAvailabilitySocketTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/lease/LeaseBasedAvailabilitySocketTest.java
@@ -1,8 +1,80 @@
-import static org.junit.Assert.*;
+package io.reactivesocket.lease;
+
+import io.reactivesocket.Payload;
+import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.util.PayloadImpl;
+import io.reactivex.Flowable;
+import org.agrona.BitUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Publisher;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Created by rroeser on 1/12/17.
+ *
  */
 public class LeaseBasedAvailabilitySocketTest {
+    @Test
+    public void testConcurrency() {
+        ByteBuffer buffer = ByteBuffer.allocate(BitUtil.SIZE_OF_INT);
+        buffer.putInt(1);
+        Lease lease = new LeaseImpl(2, (int) TimeUnit.HOURS.toMillis(1), buffer);
+        ReactiveSocket rs = Mockito.mock(ReactiveSocket.class);
+
+        Mockito.when(rs.requestResponse(Mockito.any(Payload.class)))
+            .thenReturn(Flowable.empty());
+
+        Mockito.when(rs.availability()).thenReturn(1.0);
+
+        LeaseBasedAvailabilitySocket socket = new LeaseBasedAvailabilitySocket(rs);
+        socket.accept(lease);
+
+        Assert.assertTrue("availability should be greater than zero",socket.availability() > 0);
+
+        Publisher<Payload> hi = socket.requestResponse(new PayloadImpl("hi"));
+
+        Assert.assertTrue("availability should be zero", socket.availability() <= 0);
+
+        Flowable.fromPublisher(hi).blockingSubscribe();
+
+        Assert.assertTrue("availability should be greater than zero",socket.availability() == 0.5);
+
+        hi = socket.requestResponse(new PayloadImpl("hi"));
+        Flowable.fromPublisher(hi).blockingSubscribe();
+        Assert.assertTrue("availability should be zero", socket.availability() <= 0);
+    }
+
+    @Test
+    public void testShoulBeZeroAvailibiltyWhenConcurrencyLimitIsLowerThanCocurrency() {
+        ByteBuffer buffer = ByteBuffer.allocate(BitUtil.SIZE_OF_INT);
+        buffer.putInt(10);
+        Lease lease = new LeaseImpl(200, (int) TimeUnit.HOURS.toMillis(1), buffer);
+        ReactiveSocket rs = Mockito.mock(ReactiveSocket.class);
+
+        Mockito.when(rs.requestResponse(Mockito.any(Payload.class)))
+            .thenReturn(Flowable.empty());
+
+        Mockito.when(rs.availability()).thenReturn(1.0);
+
+        LeaseBasedAvailabilitySocket socket = new LeaseBasedAvailabilitySocket(rs);
+        socket.accept(lease);
+
+        socket.requestResponse(new PayloadImpl("hi"));
+        socket.requestResponse(new PayloadImpl("hi"));
+        socket.requestResponse(new PayloadImpl("hi"));
+
+
+        Assert.assertTrue("availability should be greater than zero",socket.availability() > 0);
+
+        buffer = ByteBuffer.allocate(BitUtil.SIZE_OF_INT);
+        buffer.putInt(3);
+        lease = new LeaseImpl(200, (int) TimeUnit.HOURS.toMillis(1), buffer);
+        socket.accept(lease);
+        Assert.assertTrue("availability should be zero", socket.availability() == 0);
+
+    }
 
 }

--- a/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/stress/TestConfig.java
+++ b/reactivesocket-examples/src/main/java/io/reactivesocket/examples/transport/tcp/stress/TestConfig.java
@@ -95,7 +95,7 @@ public class TestConfig {
         if (serverCapacitySupplier == null) {
             return new DisabledLeaseAcceptingSocket(socket);
         } else {
-            FairLeaseDistributor leaseDistributor = new FairLeaseDistributor(serverCapacitySupplier, leaseTtlMillis,
+            FairLeaseDistributor leaseDistributor = new FairLeaseDistributor(serverCapacitySupplier, () -> leaseTtlMillis,
                                                                              Flowable.interval(0, leaseTtlMillis,
                                                                                                MILLISECONDS));
             return new DefaultLeaseEnforcingSocket(socket, leaseDistributor);


### PR DESCRIPTION
Problem
Leases should be tuned dynamically.

Modification
A lease capacity supplier that uses two Pid controller to determine the number of leases need. The first pid controller determines the number of leases based on rejection. The second controller bases them on pending requests. If there are pending requests this controller has precedent. Leases are decayed using an estimate that is an exponential moving average. The averages converges up faster than down so that it decays leases slowly. Right now concurrency is sent via metadata, but could added to the Lease frame.

Result
Dynamic leases based on concurrency and rps