### PR TITLE
Using native spectator counter and timer

### DIFF
--- a/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/EventListenerImpl.java
+++ b/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/EventListenerImpl.java
@@ -13,6 +13,7 @@
 
 package io.reactivesocket.spectator;
 
+import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import io.reactivesocket.FrameType;
@@ -20,26 +21,27 @@ import io.reactivesocket.events.EventListener;
 import io.reactivesocket.spectator.internal.ErrorStats;
 import io.reactivesocket.spectator.internal.LeaseStats;
 import io.reactivesocket.spectator.internal.RequestStats;
-import io.reactivesocket.spectator.internal.ThreadLocalAdderCounter;
 
 import java.util.EnumMap;
 import java.util.concurrent.TimeUnit;
+
+import static io.reactivesocket.spectator.internal.SpectatorUtil.*;
 
 public class EventListenerImpl implements EventListener {
 
     private final LeaseStats leaseStats;
     private final ErrorStats errorStats;
-    private final ThreadLocalAdderCounter socketClosed;
-    private final ThreadLocalAdderCounter frameRead;
-    private final ThreadLocalAdderCounter frameWritten;
+    private final Counter socketClosed;
+    private final Counter frameRead;
+    private final Counter frameWritten;
     private final EnumMap<RequestType, RequestStats> requestStats;
 
     public EventListenerImpl(Registry registry, String monitorId) {
         leaseStats = new LeaseStats(registry, monitorId);
         errorStats = new ErrorStats(registry, monitorId);
-        socketClosed = new ThreadLocalAdderCounter(registry, "socketClosed", monitorId);
-        frameRead = new ThreadLocalAdderCounter(registry, "frameRead", monitorId);
-        frameWritten = new ThreadLocalAdderCounter(registry, "frameWritten", monitorId);
+        socketClosed = registry.counter(createId(registry, "socketClosed", monitorId));
+        frameRead = registry.counter(createId(registry, "frameRead", monitorId));
+        frameWritten = registry.counter(createId(registry, "frameWritten", monitorId));
         requestStats = new EnumMap<RequestType, RequestStats>(RequestType.class);
         for (RequestType type : RequestType.values()) {
             requestStats.put(type, new RequestStats(registry, type, monitorId));

--- a/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/LoadBalancingClientListenerImpl.java
+++ b/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/LoadBalancingClientListenerImpl.java
@@ -13,27 +13,29 @@
 
 package io.reactivesocket.spectator;
 
+import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import io.reactivesocket.Availability;
 import io.reactivesocket.client.LoadBalancerSocketMetrics;
 import io.reactivesocket.client.events.LoadBalancingClientListener;
-import io.reactivesocket.spectator.internal.ThreadLocalAdderCounter;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import static io.reactivesocket.spectator.internal.SpectatorUtil.*;
 
 public class LoadBalancingClientListenerImpl extends ClientEventListenerImpl
         implements LoadBalancingClientListener {
 
     private final ConcurrentHashMap<Availability, SocketStats> sockets;
     private final ConcurrentHashMap<Availability, Availability> servers;
-    private final ThreadLocalAdderCounter socketsAdded;
-    private final ThreadLocalAdderCounter socketsRemoved;
-    private final ThreadLocalAdderCounter serversAdded;
-    private final ThreadLocalAdderCounter serversRemoved;
-    private final ThreadLocalAdderCounter socketRefresh;
+    private final Counter socketsAdded;
+    private final Counter socketsRemoved;
+    private final Counter serversAdded;
+    private final Counter serversRemoved;
+    private final Counter socketRefresh;
     private final Gauge aperture;
     private final Gauge socketRefreshPeriodMillis;
     private final Registry registry;
@@ -45,11 +47,11 @@ public class LoadBalancingClientListenerImpl extends ClientEventListenerImpl
         this.monitorId = monitorId;
         sockets = new ConcurrentHashMap<>();
         servers = new ConcurrentHashMap<>();
-        socketsAdded = new ThreadLocalAdderCounter(registry, "socketsAdded", monitorId);
-        socketsRemoved = new ThreadLocalAdderCounter(registry, "socketsRemoved", monitorId);
-        serversAdded = new ThreadLocalAdderCounter(registry, "serversAdded", monitorId);
-        serversRemoved = new ThreadLocalAdderCounter(registry, "serversRemoved", monitorId);
-        socketRefresh = new ThreadLocalAdderCounter(registry, "socketRefresh", monitorId);
+        socketsAdded = registry.counter(createId(registry, "socketsAdded", monitorId));
+        socketsRemoved = registry.counter(createId(registry, "socketsRemoved", monitorId));
+        serversAdded = registry.counter(createId(registry, "serversAdded", monitorId));
+        serversRemoved = registry.counter(createId(registry, "serversRemoved", monitorId));
+        socketRefresh = registry.counter(createId(registry, "socketRefresh", monitorId));
         aperture = registry.gauge(registry.createId("aperture", "id", monitorId));
         socketRefreshPeriodMillis = registry.gauge(registry.createId("socketRefreshPeriodMillis",
                                                                      "id", monitorId));

--- a/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/internal/ErrorStats.java
+++ b/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/internal/ErrorStats.java
@@ -13,34 +13,30 @@
 
 package io.reactivesocket.spectator.internal;
 
+import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 
 import static io.reactivesocket.frame.ErrorFrameFlyweight.*;
+import static io.reactivesocket.spectator.internal.SpectatorUtil.*;
 
 public class ErrorStats {
 
-    private final ThreadLocalAdderCounter connectionErrorSent;
-    private final ThreadLocalAdderCounter connectionErrorReceived;
-    private final ThreadLocalAdderCounter rejectedSent;
-    private final ThreadLocalAdderCounter rejectedReceived;
-    private final ThreadLocalAdderCounter setupFailed;
-    private final ThreadLocalAdderCounter otherSent;
-    private final ThreadLocalAdderCounter otherReceived;
+    private final Counter connectionErrorSent;
+    private final Counter connectionErrorReceived;
+    private final Counter rejectedSent;
+    private final Counter rejectedReceived;
+    private final Counter setupFailed;
+    private final Counter otherSent;
+    private final Counter otherReceived;
 
     public ErrorStats(Registry registry, String monitorId) {
-        connectionErrorSent = new ThreadLocalAdderCounter(registry, "connectionError", monitorId,
-                                                          "direction", "sent");
-        connectionErrorReceived = new ThreadLocalAdderCounter(registry, "connectionError", monitorId,
-                                                              "direction", "received");
-        rejectedSent = new ThreadLocalAdderCounter(registry, "rejects", monitorId,
-                                                   "direction", "sent");
-        rejectedReceived = new ThreadLocalAdderCounter(registry, "rejects", monitorId,
-                                                       "direction", "received");
-        setupFailed = new ThreadLocalAdderCounter(registry, "setupFailed", monitorId);
-        otherSent = new ThreadLocalAdderCounter(registry, "otherErrors", monitorId,
-                                                   "direction", "sent");
-        otherReceived = new ThreadLocalAdderCounter(registry, "otherErrors", monitorId,
-                                                       "direction", "received");
+        connectionErrorSent = registry.counter(createId(registry, "connectionError", monitorId, "direction", "sent"));
+        connectionErrorReceived = registry.counter(createId(registry, "connectionError", monitorId, "direction", "received"));
+        rejectedSent = registry.counter(createId(registry, "rejects", monitorId, "direction", "sent"));
+        rejectedReceived = registry.counter(createId(registry, "rejects", monitorId, "direction", "received"));
+        setupFailed = registry.counter(createId(registry, "setupFailed", monitorId));
+        otherSent = registry.counter(createId(registry, "otherErrors", monitorId, "direction", "sent"));
+        otherReceived = registry.counter(createId(registry, "otherErrors", monitorId, "direction", "received"));
     }
 
     public void onErrorSent(int errorCode) {
@@ -51,7 +47,7 @@ public class ErrorStats {
         getCounterForError(errorCode, false).increment();
     }
 
-    private ThreadLocalAdderCounter getCounterForError(int errorCode, boolean sent) {
+    private Counter getCounterForError(int errorCode, boolean sent) {
         switch (errorCode) {
         case INVALID_SETUP:
             return setupFailed;

--- a/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/internal/LeaseStats.java
+++ b/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/internal/LeaseStats.java
@@ -13,26 +13,23 @@
 
 package io.reactivesocket.spectator.internal;
 
+import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 
-import static io.reactivesocket.spectator.internal.SpectatorUtil.mergeTags;
+import static io.reactivesocket.spectator.internal.SpectatorUtil.*;
 
 public class LeaseStats {
 
-    private final ThreadLocalAdderCounter leaseSent;
-    private final ThreadLocalAdderCounter ttlSent;
-    private final ThreadLocalAdderCounter leaseReceived;
-    private final ThreadLocalAdderCounter ttlReceived;
+    private final Counter leaseSent;
+    private final Counter ttlSent;
+    private final Counter leaseReceived;
+    private final Counter ttlReceived;
 
     public LeaseStats(Registry registry, String monitorId, String... tags) {
-        leaseSent = new ThreadLocalAdderCounter(registry, "lease", monitorId,
-                                                mergeTags(tags, "direction", "sent"));
-        ttlSent = new ThreadLocalAdderCounter(registry, "ttl", monitorId,
-                                              mergeTags(tags, "direction", "sent"));
-        leaseReceived = new ThreadLocalAdderCounter(registry, "lease", monitorId,
-                                                    mergeTags(tags, "direction", "received"));
-        ttlReceived = new ThreadLocalAdderCounter(registry, "ttl", monitorId,
-                                                  mergeTags(tags, "direction", "received"));
+        leaseSent = registry.counter(createId(registry, "lease", monitorId, mergeTags(tags, "direction", "sent")));
+        ttlSent = registry.counter(createId(registry, "ttl", monitorId, mergeTags(tags, "direction", "sent")));
+        leaseReceived = registry.counter(createId(registry, "lease", monitorId, mergeTags(tags, "direction", "received")));
+        ttlReceived = registry.counter(createId(registry, "ttl", monitorId, mergeTags(tags, "direction", "received")));
     }
 
     public void newLeaseSent(int permits, int ttl) {

--- a/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/internal/RequestStats.java
+++ b/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/internal/RequestStats.java
@@ -13,12 +13,15 @@
 
 package io.reactivesocket.spectator.internal;
 
+import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.api.histogram.PercentileTimer;
 import io.reactivesocket.events.EventListener.RequestType;
-import io.reactivesocket.util.Clock;
 
 import java.util.concurrent.TimeUnit;
+
+import static io.reactivesocket.spectator.internal.SpectatorUtil.*;
 
 public class RequestStats {
 
@@ -48,107 +51,107 @@ public class RequestStats {
 
     public void requestSendSuccess(long duration, TimeUnit timeUnit) {
         requestSentStats.success.increment();
-        requestSentStats.successLatency.record(Clock.unit().convert(duration, timeUnit));
+        requestSentStats.successLatency.record(duration, timeUnit);
     }
 
     public void requestReceivedSuccess(long duration, TimeUnit timeUnit) {
         requestReceivedStats.success.increment();
-        requestReceivedStats.successLatency.record(Clock.unit().convert(duration, timeUnit));
+        requestReceivedStats.successLatency.record(duration, timeUnit);
     }
 
     public void requestSendFailed(long duration, TimeUnit timeUnit) {
         requestSentStats.failure.increment();
-        requestSentStats.failureLatency.record(Clock.unit().convert(duration, timeUnit));
+        requestSentStats.failureLatency.record(duration, timeUnit);
     }
 
     public void requestReceivedFailed(long duration, TimeUnit timeUnit) {
         requestReceivedStats.failure.increment();
-        requestReceivedStats.failureLatency.record(Clock.unit().convert(duration, timeUnit));
+        requestReceivedStats.failureLatency.record(duration, timeUnit);
     }
 
     public void requestSendCancelled(long duration, TimeUnit timeUnit) {
         requestSentStats.cancel.increment();
-        requestSentStats.cancelLatency.record(Clock.unit().convert(duration, timeUnit));
+        requestSentStats.cancelLatency.record(duration, timeUnit);
     }
 
     public void requestReceivedCancelled(long duration, TimeUnit timeUnit) {
         requestReceivedStats.cancel.increment();
-        requestReceivedStats.cancelLatency.record(Clock.unit().convert(duration, timeUnit));
+        requestReceivedStats.cancelLatency.record(duration, timeUnit);
     }
 
     public void responseSendStart(long requestToResponseLatency, TimeUnit timeUnit) {
         responseSentStats.start.increment();
-        responseSentStats.processLatency.record(Clock.unit().convert(requestToResponseLatency, timeUnit));
+        responseSentStats.processLatency.record(requestToResponseLatency, timeUnit);
     }
 
     public void responseReceivedStart(long requestToResponseLatency, TimeUnit timeUnit) {
         responseReceivedStats.start.increment();
-        responseReceivedStats.processLatency.record(Clock.unit().convert(requestToResponseLatency, timeUnit));
+        responseReceivedStats.processLatency.record(requestToResponseLatency, timeUnit);
     }
 
     public void responseSendSuccess(long duration, TimeUnit timeUnit) {
         responseSentStats.success.increment();
-        responseSentStats.successLatency.record(Clock.unit().convert(duration, timeUnit));
+        responseSentStats.successLatency.record(duration, timeUnit);
     }
 
     public void responseReceivedSuccess(long duration, TimeUnit timeUnit) {
         responseReceivedStats.success.increment();
-        responseReceivedStats.successLatency.record(Clock.unit().convert(duration, timeUnit));
+        responseReceivedStats.successLatency.record(duration, timeUnit);
     }
 
     public void responseSendFailed(long duration, TimeUnit timeUnit) {
         responseSentStats.failure.increment();
-        responseSentStats.failureLatency.record(Clock.unit().convert(duration, timeUnit));
+        responseSentStats.failureLatency.record(duration, timeUnit);
     }
 
     public void responseReceivedFailed(long duration, TimeUnit timeUnit) {
         responseReceivedStats.failure.increment();
-        responseReceivedStats.failureLatency.record(Clock.unit().convert(duration, timeUnit));
+        responseReceivedStats.failureLatency.record(duration, timeUnit);
     }
 
     public void responseSendCancelled(long duration, TimeUnit timeUnit) {
         responseSentStats.cancel.increment();
-        responseSentStats.cancelLatency.record(Clock.unit().convert(duration, timeUnit));
+        responseSentStats.cancelLatency.record(duration, timeUnit);
     }
 
     public void responseReceivedCancelled(long duration, TimeUnit timeUnit) {
         responseReceivedStats.cancel.increment();
-        responseReceivedStats.cancelLatency.record(Clock.unit().convert(duration, timeUnit));
+        responseReceivedStats.cancelLatency.record(duration, timeUnit);
     }
 
     private static class Stats {
 
-        private final ThreadLocalAdderCounter start;
-        private final ThreadLocalAdderCounter success;
-        private final ThreadLocalAdderCounter failure;
-        private final ThreadLocalAdderCounter cancel;
-        private final HdrHistogramPercentileTimer successLatency;
-        private final HdrHistogramPercentileTimer failureLatency;
-        private final HdrHistogramPercentileTimer cancelLatency;
-        private final HdrHistogramPercentileTimer processLatency;
+        private final Counter start;
+        private final Counter success;
+        private final Counter failure;
+        private final Counter cancel;
+        private final PercentileTimer successLatency;
+        private final PercentileTimer failureLatency;
+        private final PercentileTimer cancelLatency;
+        private final PercentileTimer processLatency;
 
         public Stats(Registry registry, RequestType requestType, String monitorId, String namePrefix,
                      String direction) {
-            start = new ThreadLocalAdderCounter(registry, namePrefix + "Start", monitorId,
-                                                "requestType", requestType.name(), "direction", direction);
-            success = new ThreadLocalAdderCounter(registry, namePrefix + "Success", monitorId,
-                                                  "requestType", requestType.name(), "direction", direction);
-            failure = new ThreadLocalAdderCounter(registry, namePrefix + "Failure", monitorId,
-                                                  "requestType", requestType.name(), "direction", direction);
-            cancel = new ThreadLocalAdderCounter(registry, namePrefix + "Cancel", monitorId,
-                                                 "requestType", requestType.name(), "direction", direction);
-            successLatency = new HdrHistogramPercentileTimer(registry, namePrefix + "Latency", monitorId,
-                                                             "requestType", requestType.name(),
-                                                             "direction", direction, "outcome", "success");
-            failureLatency = new HdrHistogramPercentileTimer(registry, namePrefix + "Latency", monitorId,
-                                                             "requestType", requestType.name(),
-                                                             "direction", direction, "outcome", "failure");
-            cancelLatency = new HdrHistogramPercentileTimer(registry, namePrefix + "Latency", monitorId,
-                                                             "requestType", requestType.name(),
-                                                             "direction", direction, "outcome", "cancel");
-            processLatency = new HdrHistogramPercentileTimer(registry, namePrefix + "processingTime", monitorId,
-                                                             "requestType", requestType.name(),
-                                                             "direction", direction);
+            start = registry.counter(createId(registry, namePrefix + "Start", monitorId,
+                                              "requestType", requestType.name(), "direction", direction));
+            success = registry.counter(createId(registry, namePrefix + "Success", monitorId,
+                                                "requestType", requestType.name(), "direction", direction));
+            failure = registry.counter(createId(registry, namePrefix + "Failure", monitorId,
+                                                "requestType", requestType.name(), "direction", direction));
+            cancel = registry.counter(createId(registry, namePrefix + "Cancel", monitorId,
+                                               "requestType", requestType.name(), "direction", direction));
+            successLatency = PercentileTimer.get(registry, createId(registry, namePrefix + "Latency", monitorId,
+                                                                    "requestType", requestType.name(),
+                                                                    "direction", direction, "outcome", "success"));
+            failureLatency = PercentileTimer.get(registry, createId(registry, namePrefix + "Latency", monitorId,
+                                                                    "requestType", requestType.name(),
+                                                                    "direction", direction, "outcome", "failure"));
+            cancelLatency = PercentileTimer.get(registry, createId(registry, namePrefix + "Latency", monitorId,
+                                                                   "requestType", requestType.name(),
+                                                                   "direction", direction, "outcome", "cancel"));
+            processLatency = PercentileTimer.get(registry, createId(registry, namePrefix + "processingTime", monitorId,
+                                                                    "requestType", requestType.name(),
+                                                                    "direction", direction));
         }
     }
 }

--- a/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/internal/SpectatorUtil.java
+++ b/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/internal/SpectatorUtil.java
@@ -13,13 +13,16 @@
 
 package io.reactivesocket.spectator.internal;
 
-final class SpectatorUtil {
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+public final class SpectatorUtil {
 
     private SpectatorUtil() {
         // No instances
     }
 
-    static String[] mergeTags(String[] tags1, String... tags2) {
+    public static String[] mergeTags(String[] tags1, String... tags2) {
         if (tags1.length == 0) {
             return tags2;
         }
@@ -31,5 +34,9 @@ final class SpectatorUtil {
         System.arraycopy(tags1, 0, toReturn, 0, tags1.length);
         System.arraycopy(tags2, 0, toReturn, tags1.length, tags2.length);
         return toReturn;
+    }
+
+    public static Id createId(Registry registry, String name, String monitorId, String... tags) {
+        return registry.createId(name, mergeTags(tags, "id", monitorId));
     }
 }


### PR DESCRIPTION
__Problem__

Currently we have custom implementation of timers and counters.
These implementations are somewhat not recognized inside Netflix and hence does not get published to our metrics system.
At this point it is better to use the native counterparts than to debug the issue, we can revert to the custom implementation when we see performance issues.

 __Modification__

 Replace custom usages with native spectator classes.

 __Result__

 Metrics correctly published.