### PR TITLE
Missed moving to native spectator counter.

### DIFF
--- a/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/ServerEventListenerImpl.java
+++ b/reactivesocket-spectator/src/main/java/io/reactivesocket/spectator/ServerEventListenerImpl.java
@@ -13,18 +13,19 @@
 
 package io.reactivesocket.spectator;
 
+import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import io.reactivesocket.events.ServerEventListener;
-import io.reactivesocket.spectator.internal.ThreadLocalAdderCounter;
+import io.reactivesocket.spectator.internal.SpectatorUtil;
 
 public class ServerEventListenerImpl extends EventListenerImpl implements ServerEventListener {
 
-    private final ThreadLocalAdderCounter socketAccepted;
+    private final Counter socketAccepted;
 
     public ServerEventListenerImpl(Registry registry, String monitorId) {
         super(registry, monitorId);
-        socketAccepted = new ThreadLocalAdderCounter(registry, "socketAccepted", monitorId);
+        socketAccepted = registry.counter(SpectatorUtil.createId(registry, "socketAccepted", monitorId));
     }
 
     public ServerEventListenerImpl(String monitorId) {


### PR DESCRIPTION
__Problem__

Missed in #228

 __Modification__

Remove the remaining `ThreadLocalAdderCounter`

 __Result__

 Metrics correctly published.