### PR TITLE
Update SETUP frame to 1.0 spec

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/frame/RequestFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/frame/RequestFrameFlyweight.java
@@ -27,8 +27,9 @@ public class RequestFrameFlyweight {
 
     private RequestFrameFlyweight() {}
 
-    public static final int FLAGS_REQUEST_CHANNEL_C = 0b0001_0000_0000_0000;
-    public static final int FLAGS_REQUEST_CHANNEL_N = 0b0000_1000_0000_0000;
+    public static final int FLAGS_REQUEST_CHANNEL_C = 0b00_0100_0000;
+    // TODO(lexs) Remove flag for initial N present
+    public static final int FLAGS_REQUEST_CHANNEL_N = 0b00_0010_0000;
 
     // relative to start of passed offset
     private static final int INITIAL_REQUEST_N_FIELD_OFFSET = FrameHeaderFlyweight.FRAME_HEADER_LENGTH;

--- a/reactivesocket-core/src/main/java/io/reactivesocket/frame/SetupFrameFlyweight.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/frame/SetupFrameFlyweight.java
@@ -27,8 +27,9 @@ import java.nio.charset.StandardCharsets;
 public class SetupFrameFlyweight {
     private SetupFrameFlyweight() {}
 
-    public static final int FLAGS_WILL_HONOR_LEASE = 0b0010_0000;
-    public static final int FLAGS_STRICT_INTERPRETATION = 0b0001_0000;
+    // TODO(lexs) Add Resume enabled
+    public static final int FLAGS_WILL_HONOR_LEASE = 0b00_0100_0000;
+    public static final int FLAGS_STRICT_INTERPRETATION = 0b00_0010_0000;
 
     public static final byte CURRENT_VERSION = 0;
 

--- a/reactivesocket-core/src/test/java/io/reactivesocket/frame/FrameHeaderFlyweightTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/frame/FrameHeaderFlyweightTest.java
@@ -1,0 +1,102 @@
+package io.reactivesocket.frame;
+
+import io.reactivesocket.FrameType;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static io.reactivesocket.frame.FrameHeaderFlyweight.NULL_BYTEBUFFER;
+import static org.junit.Assert.*;
+
+public class FrameHeaderFlyweightTest {
+    // Taken from spec
+    private static final int FRAME_MAX_SIZE = 16_777_215;
+
+    private final UnsafeBuffer directBuffer = new UnsafeBuffer(ByteBuffer.allocate(1024));
+
+    @Test
+    public void headerSize() {
+        int frameLength = 123456;
+        FrameHeaderFlyweight.encodeFrameHeader(directBuffer, 0, frameLength, 0, FrameType.SETUP, 0);
+        assertEquals(frameLength, FrameHeaderFlyweight.frameLength(directBuffer, 0, frameLength));
+    }
+
+    @Test
+    public void headerSizeMax() {
+        int frameLength = FRAME_MAX_SIZE;
+        FrameHeaderFlyweight.encodeFrameHeader(directBuffer, 0, frameLength, 0, FrameType.SETUP, 0);
+        assertEquals(frameLength, FrameHeaderFlyweight.frameLength(directBuffer, 0, frameLength));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void headerSizeTooLarge() {
+        FrameHeaderFlyweight.encodeFrameHeader(directBuffer, 0, FRAME_MAX_SIZE + 1, 0, FrameType.SETUP, 0);
+    }
+
+    @Test
+    public void frameLength() {
+        int length = FrameHeaderFlyweight.encode(directBuffer, 0, 0, 0, FrameType.SETUP, NULL_BYTEBUFFER, NULL_BYTEBUFFER);
+        assertEquals(length, 9); // 72 bits
+    }
+
+    @Test
+    public void metadataLength() {
+        ByteBuffer metadata = ByteBuffer.wrap(new byte[]{1, 2, 3, 4});
+        FrameHeaderFlyweight.encode(directBuffer, 0, 0, 0, FrameType.SETUP, metadata, NULL_BYTEBUFFER);
+        assertEquals(4, FrameHeaderFlyweight.metadataLength(directBuffer, 0, FrameHeaderFlyweight.FRAME_HEADER_LENGTH));
+    }
+
+    @Test
+    public void dataLength() {
+        ByteBuffer data = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
+        int length = FrameHeaderFlyweight.encode(directBuffer, 0, 0, 0, FrameType.SETUP, NULL_BYTEBUFFER, data);
+        assertEquals(5, FrameHeaderFlyweight.dataLength(directBuffer, 0, length, FrameHeaderFlyweight.FRAME_HEADER_LENGTH));
+    }
+
+    @Test
+    public void metadataSlice() {
+        ByteBuffer metadata = ByteBuffer.wrap(new byte[]{1, 2, 3, 4});
+        FrameHeaderFlyweight.encode(directBuffer, 0, 0, 0, FrameType.REQUEST_RESPONSE, metadata, NULL_BYTEBUFFER);
+        metadata.rewind();
+
+        assertEquals(metadata, FrameHeaderFlyweight.sliceFrameMetadata(directBuffer, 0, FrameHeaderFlyweight.FRAME_HEADER_LENGTH));
+    }
+
+    @Test
+    public void dataSlice() {
+        ByteBuffer data = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
+        FrameHeaderFlyweight.encode(directBuffer, 0, 0, 0, FrameType.REQUEST_RESPONSE, NULL_BYTEBUFFER, data);
+        data.rewind();
+
+        assertEquals(data, FrameHeaderFlyweight.sliceFrameData(directBuffer, 0, FrameHeaderFlyweight.FRAME_HEADER_LENGTH));
+    }
+
+    @Test
+    public void streamId() {
+        int streamId = 1234;
+        FrameHeaderFlyweight.encode(directBuffer, 0, streamId, 0, FrameType.SETUP, NULL_BYTEBUFFER, NULL_BYTEBUFFER);
+        assertEquals(streamId, FrameHeaderFlyweight.streamId(directBuffer, 0));
+    }
+
+    @Test
+    public void typeAndFlag() {
+        FrameType frameType = FrameType.FIRE_AND_FORGET;
+        int flags = 0b1110110111;
+        FrameHeaderFlyweight.encode(directBuffer, 0, 0, flags, frameType, NULL_BYTEBUFFER, NULL_BYTEBUFFER);
+
+        assertEquals(flags, FrameHeaderFlyweight.flags(directBuffer, 0));
+        assertEquals(frameType, FrameHeaderFlyweight.frameType(directBuffer, 0));
+    }
+
+    @Test
+    public void typeAndFlagTruncated() {
+        FrameType frameType = FrameType.SETUP;
+        int flags = 0b11110110111; // 1 bit too many
+        FrameHeaderFlyweight.encode(directBuffer, 0, 0, flags, FrameType.SETUP, NULL_BYTEBUFFER, NULL_BYTEBUFFER);
+
+        assertNotEquals(flags, FrameHeaderFlyweight.flags(directBuffer, 0));
+        assertEquals(flags & 0b0000_0011_1111_1111, FrameHeaderFlyweight.flags(directBuffer, 0));
+        assertEquals(frameType, FrameHeaderFlyweight.frameType(directBuffer, 0));
+    }
+}

--- a/reactivesocket-core/src/test/java/io/reactivesocket/frame/SetupFrameFlyweightTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/frame/SetupFrameFlyweightTest.java
@@ -1,0 +1,30 @@
+package io.reactivesocket.frame;
+
+import io.reactivesocket.FrameType;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.*;
+
+public class SetupFrameFlyweightTest {
+    private final UnsafeBuffer directBuffer = new UnsafeBuffer(ByteBuffer.allocate(1024));
+
+    @Test
+    public void validFrame() {
+        ByteBuffer metadata = ByteBuffer.wrap(new byte[]{1, 2, 3, 4});
+        ByteBuffer data = ByteBuffer.wrap(new byte[]{5, 4, 3});
+        SetupFrameFlyweight.encode(directBuffer, 0, 0, 5, 500, "metadata_type", "data_type", metadata, data);
+
+        metadata.rewind();
+        data.rewind();
+
+        assertEquals(FrameType.SETUP, FrameHeaderFlyweight.frameType(directBuffer, 0));
+        assertEquals("metadata_type", SetupFrameFlyweight.metadataMimeType(directBuffer, 0));
+        assertEquals("data_type", SetupFrameFlyweight.dataMimeType(directBuffer, 0));
+        assertEquals(metadata, FrameHeaderFlyweight.sliceFrameMetadata(directBuffer, 0, FrameHeaderFlyweight.FRAME_HEADER_LENGTH));
+        assertEquals(data, FrameHeaderFlyweight.sliceFrameData(directBuffer, 0, FrameHeaderFlyweight.FRAME_HEADER_LENGTH));
+    }
+
+}

--- a/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/ReactiveSocketLengthCodec.java
+++ b/reactivesocket-transport-tcp/src/main/java/io/reactivesocket/transport/tcp/ReactiveSocketLengthCodec.java
@@ -17,11 +17,13 @@
 package io.reactivesocket.transport.tcp;
 
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import org.agrona.BitUtil;
+
+import static io.reactivesocket.frame.FrameHeaderFlyweight.FRAME_LENGTH_MASK;
+import static io.reactivesocket.frame.FrameHeaderFlyweight.FRAME_LENGTH_SIZE;
 
 public class ReactiveSocketLengthCodec extends LengthFieldBasedFrameDecoder {
 
     public ReactiveSocketLengthCodec() {
-        super(Integer.MAX_VALUE, 0, BitUtil.SIZE_OF_INT, -1 * BitUtil.SIZE_OF_INT, 0);
+        super(FRAME_LENGTH_MASK, 0, FRAME_LENGTH_SIZE, -1 * FRAME_LENGTH_SIZE, 0);
     }
 }


### PR DESCRIPTION
Makes frame and metadata length 24 bits.
Metadata length also excludes the length field itself
Moves streamId to front
Makes frame type 6 bits and flags 10 bits
Make all used flag 10 bits