### PR TITLE
Add last position to KEEPALIVE frame

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
@@ -18,6 +18,7 @@ package io.reactivesocket;
 import io.reactivesocket.frame.ErrorFrameFlyweight;
 import io.reactivesocket.frame.FrameHeaderFlyweight;
 import io.reactivesocket.frame.FramePool;
+import io.reactivesocket.frame.KeepaliveFrameFlyweight;
 import io.reactivesocket.frame.LeaseFrameFlyweight;
 import io.reactivesocket.frame.RequestFrameFlyweight;
 import io.reactivesocket.frame.RequestNFrameFlyweight;
@@ -510,12 +511,11 @@ public class Frame implements Payload {
 
         public static Frame from(ByteBuffer data, boolean respond) {
             final Frame frame =
-                POOL.acquireFrame(FrameHeaderFlyweight.computeFrameHeaderLength(FrameType.KEEPALIVE, 0, data.remaining()));
+                POOL.acquireFrame(KeepaliveFrameFlyweight.computeFrameLength(data.remaining()));
 
             final int flags = respond ? FrameHeaderFlyweight.FLAGS_KEEPALIVE_R : 0;
 
-            frame.length = FrameHeaderFlyweight.encode(
-                frame.directBuffer, frame.offset, 0, flags, FrameType.KEEPALIVE, Frame.NULL_BYTEBUFFER, data);
+            frame.length = KeepaliveFrameFlyweight.encode(frame.directBuffer, frame.offset, flags, data);
 
             return frame;
         }

--- a/reactivesocket-core/src/test/java/io/reactivesocket/frame/KeepaliveFrameFlyweightTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/frame/KeepaliveFrameFlyweightTest.java
@@ -1,0 +1,22 @@
+package io.reactivesocket.frame;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.*;
+
+public class KeepaliveFrameFlyweightTest {
+    private final UnsafeBuffer directBuffer = new UnsafeBuffer(ByteBuffer.allocate(1024));
+
+    @Test
+    public void canReadData() {
+        ByteBuffer data = ByteBuffer.wrap(new byte[]{5, 4, 3});
+        int length = KeepaliveFrameFlyweight.encode(directBuffer, 0, FrameHeaderFlyweight.FLAGS_KEEPALIVE_R, data);
+        data.rewind();
+
+        assertEquals(FrameHeaderFlyweight.FLAGS_KEEPALIVE_R, FrameHeaderFlyweight.flags(directBuffer, 0) & FrameHeaderFlyweight.FLAGS_KEEPALIVE_R);
+        assertEquals(data, FrameHeaderFlyweight.sliceFrameData(directBuffer, 0, length));
+    }
+}


### PR DESCRIPTION
Adds a 64 bit (always zero) last position to the KEEPALIVE. It's also skipped when reading. Simple unit test to verify we can still read data.