### PR TITLE
Implement Payload NEXT bit

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/ServerReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ServerReactiveSocket.java
@@ -283,7 +283,7 @@ public class ServerReactiveSocket implements ReactiveSocket {
                     }
                 })
                 .map(payload -> Frame.PayloadFrame
-                    .from(streamId, FrameType.PAYLOAD, payload.getMetadata(), payload.getData(), FrameHeaderFlyweight.FLAGS_C))
+                    .from(streamId, FrameType.NEXT_COMPLETE, payload.getMetadata(), payload.getData(), FrameHeaderFlyweight.FLAGS_C))
                 .doOnComplete(cleanup)
                 .emitOnCancelOrError(
                     // on cancel
@@ -304,7 +304,7 @@ public class ServerReactiveSocket implements ReactiveSocket {
     private Publisher<Void> doReceive(int streamId, Publisher<Payload> response, RequestType requestType) {
         long now = publishSingleFrameReceiveEvents(streamId, requestType);
         Px<Frame> resp = Px.from(response)
-                           .map(payload -> PayloadFrame.from(streamId, FrameType.PAYLOAD, payload));
+                           .map(payload -> PayloadFrame.from(streamId, FrameType.NEXT, payload));
         RemoteSender sender = new RemoteSender(resp, () -> subscriptions.remove(streamId), streamId, 2);
         subscriptions.put(streamId, sender);
         return eventPublishingSocket.decorateSend(streamId, connection.send(sender), now, requestType);
@@ -320,7 +320,7 @@ public class ServerReactiveSocket implements ReactiveSocket {
 
         Px<Frame> response = Px.from(requestChannel(eventPublishingSocket.decorateReceive(streamId, receiver,
                                                                                           RequestChannel)))
-            .map(payload -> Frame.PayloadFrame.from(streamId, FrameType.PAYLOAD, payload));
+            .map(payload -> Frame.PayloadFrame.from(streamId, FrameType.NEXT, payload));
 
         RemoteSender sender = new RemoteSender(response, () -> removeSubscriptions(streamId), streamId,
             initialRequestN);

--- a/reactivesocket-core/src/test/java/io/reactivesocket/ClientReactiveSocketTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/ClientReactiveSocketTest.java
@@ -122,7 +122,7 @@ public class ClientReactiveSocketTest {
         TestSubscriber<Payload> sub = TestSubscriber.create();
         response.subscribe(sub);
         int streamId = rule.getStreamIdForRequestType(REQUEST_RESPONSE);
-        rule.connection.addToReceivedBuffer(Frame.PayloadFrame.from(streamId, PAYLOAD, PayloadImpl.EMPTY));
+        rule.connection.addToReceivedBuffer(Frame.PayloadFrame.from(streamId, NEXT_COMPLETE, PayloadImpl.EMPTY));
         sub.assertValueCount(1).assertNoErrors();
         return streamId;
     }

--- a/reactivesocket-core/src/test/java/io/reactivesocket/FrameTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/FrameTest.java
@@ -87,7 +87,7 @@ public class FrameTest
 
         Frame f = Frame.Request.from(1, FrameType.REQUEST_RESPONSE, payload, 1);
 
-        f.wrap(2, FrameType.COMPLETE, doneBuffer);
+        f.wrap(2, FrameType.NEXT_COMPLETE, doneBuffer);
         assertEquals("done", TestUtil.byteToString(f.getData()));
         assertEquals(FrameType.NEXT_COMPLETE, f.getType());
         assertEquals(2, f.getStreamId());
@@ -101,7 +101,7 @@ public class FrameTest
         final Payload anotherPayload = createPayload(Frame.NULL_BYTEBUFFER, anotherBuffer);
 
         Frame f = Frame.Request.from(1, FrameType.REQUEST_RESPONSE, payload, 1);
-        Frame f2 = Frame.PayloadFrame.from(20, FrameType.COMPLETE, anotherPayload);
+        Frame f2 = Frame.PayloadFrame.from(20, FrameType.NEXT_COMPLETE, anotherPayload);
 
         ByteBuffer b = f2.getByteBuffer();
         f.wrap(b, 0);
@@ -174,7 +174,7 @@ public class FrameTest
         final ByteBuffer requestMetadata = TestUtil.byteBufferFromUtf8String("response metadata");
         final Payload payload = createPayload(requestMetadata, requestData);
 
-        Frame encodedFrame = Frame.PayloadFrame.from(1, FrameType.PAYLOAD, payload);
+        Frame encodedFrame = Frame.PayloadFrame.from(1, FrameType.NEXT, payload);
         TestUtil.copyFrame(reusableMutableDirectBuffer, offset, encodedFrame);
         reusableFrame.wrap(reusableMutableDirectBuffer, offset);
 
@@ -249,7 +249,7 @@ public class FrameTest
         final ByteBuffer requestData = TestUtil.byteBufferFromUtf8String("response data");
         final Payload payload = createPayload(Frame.NULL_BYTEBUFFER, requestData);
 
-        Frame encodedFrame = Frame.PayloadFrame.from(1, FrameType.PAYLOAD, payload);
+        Frame encodedFrame = Frame.PayloadFrame.from(1, FrameType.NEXT, payload);
         TestUtil.copyFrame(reusableMutableDirectBuffer, offset, encodedFrame);
         reusableFrame.wrap(reusableMutableDirectBuffer, offset);
 

--- a/reactivesocket-core/src/test/java/io/reactivesocket/frame/FrameHeaderFlyweightTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/frame/FrameHeaderFlyweightTest.java
@@ -116,12 +116,11 @@ public class FrameHeaderFlyweightTest {
         expectedMutable.putInt(currentIndex, 5, ByteOrder.BIG_ENDIAN);
         currentIndex += BitUtil.SIZE_OF_INT;
         // flags and frame type
-        expectedMutable.putShort(currentIndex, (short) 0b001010_0001000000, ByteOrder.BIG_ENDIAN);
+        expectedMutable.putShort(currentIndex, (short) 0b001010_0001100000, ByteOrder.BIG_ENDIAN);
         currentIndex += BitUtil.SIZE_OF_SHORT;
 
-        FrameType frameType = FrameType.PAYLOAD;
-        int flags = 0b0001000000;
-        FrameHeaderFlyweight.encode(directBuffer, 0, 5, flags, frameType, NULL_BYTEBUFFER, NULL_BYTEBUFFER);
+        FrameType frameType = FrameType.NEXT_COMPLETE;
+        FrameHeaderFlyweight.encode(directBuffer, 0, 5, 0, frameType, NULL_BYTEBUFFER, NULL_BYTEBUFFER);
 
         ByteBuffer expected = ByteBufferUtil.preservingSlice(expectedMutable.byteBuffer(), 0, currentIndex);
         ByteBuffer actual = ByteBufferUtil.preservingSlice(directBuffer.byteBuffer(), 0, FRAME_HEADER_LENGTH);

--- a/reactivesocket-examples/src/test/java/io/reactivesocket/integration/IntegrationTest2.java
+++ b/reactivesocket-examples/src/test/java/io/reactivesocket/integration/IntegrationTest2.java
@@ -1,0 +1,105 @@
+package io.reactivesocket.integration;
+
+import io.reactivesocket.ReactiveSocket;
+import io.reactivesocket.client.KeepAliveProvider;
+import io.reactivesocket.client.ReactiveSocketClient;
+import io.reactivesocket.client.SetupProvider;
+import io.reactivesocket.lease.DisabledLeaseAcceptingSocket;
+import io.reactivesocket.server.ReactiveSocketServer;
+import io.reactivesocket.transport.TransportServer;
+import io.reactivesocket.transport.tcp.client.TcpTransportClient;
+import io.reactivesocket.transport.tcp.server.TcpTransportServer;
+import io.reactivesocket.util.PayloadImpl;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class IntegrationTest2 {
+    // This will throw as it completes without any onNext
+    @Test(timeout = 2_000L, expected = NoSuchElementException.class)
+    public void testCompleteWithoutNext() throws InterruptedException {
+        ReactiveSocket requestHandler = mock(ReactiveSocket.class);
+
+        when(requestHandler.requestStream(any()))
+                .thenReturn(Flowable.empty());
+
+        TransportServer.StartedServer server = ReactiveSocketServer.create(TcpTransportServer.create())
+                .start((setup, sendingSocket) -> {
+                    Flowable.fromPublisher(sendingSocket.onClose())
+                            .subscribe();
+
+                    return new DisabledLeaseAcceptingSocket(requestHandler);
+                });
+        ReactiveSocket client = Single.fromPublisher(ReactiveSocketClient.create(TcpTransportClient.create(server.getServerAddress()),
+                SetupProvider.keepAlive(KeepAliveProvider.never())
+                        .disableLease())
+                .connect())
+                .blockingGet();
+
+        Flowable.fromPublisher(client.requestStream(new PayloadImpl("REQUEST", "META")))
+                .blockingFirst();
+
+        Thread.sleep(100);
+        verify(requestHandler).requestStream(new PayloadImpl("REQUEST", "META"));
+    }
+
+    @Test(timeout = 2_000L)
+    public void testSingle() throws InterruptedException {
+        ReactiveSocket requestHandler = mock(ReactiveSocket.class);
+
+        when(requestHandler.requestStream(any()))
+                .thenReturn(Flowable.just(new PayloadImpl("RESPONSE", "METADATA")));
+
+        TransportServer.StartedServer server = ReactiveSocketServer.create(TcpTransportServer.create())
+                .start((setup, sendingSocket) -> {
+                    Flowable.fromPublisher(sendingSocket.onClose())
+                            .subscribe();
+
+                    return new DisabledLeaseAcceptingSocket(requestHandler);
+                });
+        ReactiveSocket client = Single.fromPublisher(ReactiveSocketClient.create(TcpTransportClient.create(server.getServerAddress()),
+                SetupProvider.keepAlive(KeepAliveProvider.never())
+                        .disableLease())
+                .connect())
+                .blockingGet();
+
+        Flowable.fromPublisher(client.requestStream(new PayloadImpl("REQUEST", "META")))
+                .blockingSingle();
+
+        verify(requestHandler).requestStream(any());
+    }
+
+    @Test()
+    public void testZeroPayload() throws InterruptedException {
+        ReactiveSocket requestHandler = mock(ReactiveSocket.class);
+
+        when(requestHandler.requestStream(any()))
+                .thenReturn(Flowable.just(PayloadImpl.EMPTY));
+
+        TransportServer.StartedServer server = ReactiveSocketServer.create(TcpTransportServer.create())
+                .start((setup, sendingSocket) -> {
+                    Flowable.fromPublisher(sendingSocket.onClose())
+                            .subscribe();
+
+                    return new DisabledLeaseAcceptingSocket(requestHandler);
+                });
+        ReactiveSocket client = Single.fromPublisher(ReactiveSocketClient.create(TcpTransportClient.create(server.getServerAddress()),
+                SetupProvider.keepAlive(KeepAliveProvider.never())
+                        .disableLease())
+                .connect())
+                .blockingGet();
+
+        int dataSize = Flowable.fromPublisher(client.requestStream(new PayloadImpl("REQUEST", "META")))
+                .map(p -> p.getData().remaining())
+                .blockingSingle();
+
+        verify(requestHandler).requestStream(any());
+        Assert.assertEquals(0, dataSize);
+    }
+}


### PR DESCRIPTION
The existing COMPLETE frame now generates a real PAYLOAD frame with the NEXT bit unset but the COMPLETE bit set. NEXT_COMPLETE sets both while NEXT only sets the NEXT bit.

Added tests to verify this behavior and also used reactivesocket-cli to verify frames sent/received.

Currently throwing an exception if we see a PAYLOAD frame with neither NEXT nor COMPLETE set pending https://github.com/ReactiveSocket/reactivesocket/issues/226.