### PR TITLE
Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ dependencies {
 No releases to Maven Central or JCenter have occurred yet.
 
 
+## Debugging
+Frames can be printed out to help debugging. Set the logger `io.reactivesocket.FrameLogger` to debug to print the frames.
+
 ## Bugs and Feedback
 
 For bugs, questions and discussions please use the [Github Issues](https://github.com/ReactiveSocket/reactivesocket-java/issues).

--- a/reactivesocket-transport-netty/src/test/resources/log4j.properties
+++ b/reactivesocket-transport-netty/src/test/resources/log4j.properties
@@ -14,4 +14,5 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] (%F:%L) - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss,SSS} %5p [%t] (%F) - %m%n
+#log4j.logger.io.reactivesocket.FrameLogger=Debug


### PR DESCRIPTION
Problem
Can't log frames (#254)

Changes
Added a logger to the ClientServerInputMultiplexer class to the log frames when io.reactivesocket.FrameLogger is set to debug

Result
When io.reactivesocket.FrameLogger is set to debug Frames will be toStringed and logged