### PR TITLE
fixes client stream request n

### DIFF
--- a/reactivesocket-core/src/jmh/java/io/reactivesocket/ReactiveSocketPerf.java
+++ b/reactivesocket-core/src/jmh/java/io/reactivesocket/ReactiveSocketPerf.java
@@ -65,16 +65,19 @@ public class ReactiveSocketPerf {
         }
     }
 
-    //@Benchmark
+    @Benchmark
     public void requestStreamHello1000(Input input) {
-        // this is synchronous so we don't need to use a CountdownLatch to wait
-        //Input.client.requestStream(Input.HELLO_PAYLOAD).subscribe(input.blackholeConsumer);
+        try {
+            input.client.requestStream(Input.HELLO_PAYLOAD).subscribe(input.blackHoleSubscriber);
+        }  catch (Throwable t) {
+            t.printStackTrace();
+        }
     }
 
-    //@Benchmark
+    @Benchmark
     public void fireAndForgetHello(Input input) {
         // this is synchronous so we don't need to use a CountdownLatch to wait
-        //Input.client.fireAndForget(Input.HELLO_PAYLOAD).subscribe(input.voidBlackholeConsumer);
+        input.client.fireAndForget(Input.HELLO_PAYLOAD).subscribe(input.blackHoleSubscriber);
     }
 
     @State(Scope.Thread)
@@ -172,7 +175,7 @@ public class ReactiveSocketPerf {
 
                     @Override
                     public Flux<Payload> requestStream(Payload payload) {
-                        return Flux.empty();
+                        return Flux.range(1, 1_000).flatMap(i -> requestResponse(payload));
                     }
 
                     @Override

--- a/reactivesocket-core/src/main/java/io/reactivesocket/ClientReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ClientReactiveSocket.java
@@ -77,7 +77,7 @@ public class ClientReactiveSocket implements ReactiveSocket {
     public Mono<Void> fireAndForget(Payload payload) {
         Mono<Void> defer = Mono.defer(() -> {
             final int streamId = streamIdSupplier.nextStreamId();
-            final Frame requestFrame = Frame.Request.from(streamId, FrameType.FIRE_AND_FORGET, payload, 0);
+            final Frame requestFrame = Frame.Request.from(streamId, FrameType.FIRE_AND_FORGET, payload, 1);
             return connection.sendOne(requestFrame);
         });
 
@@ -101,7 +101,7 @@ public class ClientReactiveSocket implements ReactiveSocket {
 
     @Override
     public Mono<Void> metadataPush(Payload payload) {
-        final Frame requestFrame = Frame.Request.from(0, FrameType.METADATA_PUSH, payload, 0);
+        final Frame requestFrame = Frame.Request.from(0, FrameType.METADATA_PUSH, payload, 1);
         return connection.sendOne(requestFrame);
     }
 

--- a/reactivesocket-core/src/main/java/io/reactivesocket/ClientReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ClientReactiveSocket.java
@@ -18,6 +18,7 @@ package io.reactivesocket;
 
 import io.reactivesocket.client.KeepAliveProvider;
 import io.reactivesocket.exceptions.Exceptions;
+import io.reactivesocket.frame.ByteBufferUtil;
 import io.reactivesocket.internal.KnownErrorFilter;
 import io.reactivesocket.internal.LimitableRequestPublisher;
 import io.reactivesocket.lease.Lease;
@@ -31,10 +32,10 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.UnicastProcessor;
 
-import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
-import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Client Side of a ReactiveSocket socket. Sends {@link Frame}s
@@ -62,19 +63,20 @@ public class ClientReactiveSocket implements ReactiveSocket {
         this.streamIdSupplier = streamIdSupplier;
         this.keepAliveProvider = keepAliveProvider;
         this.started = MonoProcessor.create();
+        this.senders = new Int2ObjectHashMap<>(256, 0.9f);
+        this.receivers = new Int2ObjectHashMap<>(256, 0.9f);
 
-        senders = new Int2ObjectHashMap<>(256, 0.9f);
-        receivers = new Int2ObjectHashMap<>(256, 0.9f);
         connection
             .onClose()
             .doFinally(signalType -> cleanup())
+            .doOnError(errorConsumer::accept)
             .subscribe();
     }
 
     @Override
     public Mono<Void> fireAndForget(Payload payload) {
         Mono<Void> defer = Mono.defer(() -> {
-            final int streamId = nextStreamId();
+            final int streamId = streamIdSupplier.nextStreamId();
             final Frame requestFrame = Frame.Request.from(streamId, FrameType.FIRE_AND_FORGET, payload, 0);
             return connection.sendOne(requestFrame);
         });
@@ -137,7 +139,7 @@ public class ClientReactiveSocket implements ReactiveSocket {
 
     private Mono<Payload> handleRequestResponse(final Payload payload) {
         return started.then(() -> {
-            int streamId = nextStreamId();
+            int streamId = streamIdSupplier.nextStreamId();
             final Frame requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_RESPONSE, payload, 1);
 
             MonoProcessor<Payload> receiver = MonoProcessor.create();
@@ -146,8 +148,8 @@ public class ClientReactiveSocket implements ReactiveSocket {
                 receivers.put(streamId, receiver);
             }
 
-            MonoProcessor<Void> subscribedRequest = connection
-                .sendOne(requestFrame)
+            MonoProcessor<Void> subscribedRequest =
+                connection.sendOne(requestFrame)
                 .doOnError(t -> {
                     errorConsumer.accept(t);
                     receiver.cancel();
@@ -179,62 +181,98 @@ public class ClientReactiveSocket implements ReactiveSocket {
     }
 
     private Flux<Payload> handleStreamResponse(Flux<Payload> request, FrameType requestType) {
-        return started.thenMany(() -> {
-            int streamId = nextStreamId();
+        return started.thenMany(new Supplier<Publisher<Payload>>() {
+            final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
+            final int streamId = streamIdSupplier.nextStreamId();
+            volatile MonoProcessor<Void> subscribedRequests;
+            boolean firstRequest = true;
 
-            UnicastProcessor<Payload> receiver = UnicastProcessor.create();
+            boolean isValidToSendFrame() {
+                return contains(streamId) && connection.availability() > 0.0 && !receiver.isTerminated();
+            }
 
-            Flux<Frame> requestFrames =
-                request
-                    .transform(f -> {
-                        LimitableRequestPublisher<Payload> wrapped = LimitableRequestPublisher.wrap(f);
+            void sendOneFrame(Frame frame) {
+                if (isValidToSendFrame()) {
+                    connection
+                        .sendOne(frame)
+                        .doOnError(errorConsumer::accept)
+                        .subscribe();
+                }
+            }
+
+            @Override
+            public Publisher<Payload> get() {
+                return receiver
+                    .doOnRequest(l -> {
+                        boolean _firstRequest = false;
                         synchronized (ClientReactiveSocket.this) {
-                            senders.put(streamId, wrapped);
-                            receivers.put(streamId, receiver);
+                            if (firstRequest) {
+                                _firstRequest = true;
+                                firstRequest = false;
+                            }
                         }
 
-                        return wrapped;
+                        if (_firstRequest) {
+                            Flux<Frame> requestFrames =
+                                request
+                                    .transform(f -> {
+                                        LimitableRequestPublisher<Payload> wrapped = LimitableRequestPublisher.wrap(f);
+                                        synchronized (ClientReactiveSocket.this) {
+                                            senders.put(streamId, wrapped);
+                                            receivers.put(streamId, receiver);
+                                        }
+
+                                        return wrapped;
+                                    })
+                                    .map(new Function<Payload, Frame>() {
+                                        boolean firstPayload = true;
+
+                                        @Override
+                                        public Frame apply(Payload payload) {
+                                            boolean _firstPayload = false;
+                                            synchronized (this) {
+                                                if (firstPayload) {
+                                                    firstPayload = false;
+                                                    _firstPayload = true;
+                                                }
+                                            }
+
+                                            if (_firstPayload) {
+                                                return Frame.Request.from(streamId, requestType, payload, l);
+                                            } else {
+                                                return Frame.PayloadFrame.from(streamId, FrameType.NEXT, payload);
+                                            }
+                                        }
+                                    })
+                                    .doOnComplete(() -> {
+                                        if (FrameType.REQUEST_CHANNEL == requestType) {
+                                            sendOneFrame(Frame.PayloadFrame.from(streamId, FrameType.COMPLETE));
+                                        }
+                                    });
+
+                            subscribedRequests = connection
+                                .send(requestFrames)
+                                .doOnError(t -> {
+                                    errorConsumer.accept(t);
+                                    receiver.cancel();
+                                })
+                                .subscribe();
+                        } else {
+                            sendOneFrame(Frame.RequestN.from(streamId, l));
+                        }
                     })
-                    .map(payload -> Frame.Request.from(streamId, requestType, payload, 1));
-
-            MonoProcessor<Void> subscribedRequests = connection
-                .send(requestFrames)
-                .doOnError(t -> {
-                    errorConsumer.accept(t);
-                    receiver.cancel();
-                })
-                .subscribe();
-
-            return receiver
-                .doOnRequest(l -> {
-                    if (contains(streamId) && connection.availability() > 0.0 && !receiver.isTerminated()) {
-                        connection
-                            .sendOne(Frame.RequestN.from(streamId, l))
-                            .doOnError(receiver::onError)
-                            .subscribe();
-                    }
-                })
-                .doOnError(t -> {
-                    if (contains(streamId) && connection.availability() > 0.0 && !receiver.isTerminated()) {
-                        connection
-                            .sendOne(Frame.Error.from(streamId, t))
-                            .doOnError(errorConsumer::accept)
-                            .subscribe();
-                    }
-                })
-                .doOnCancel(() -> {
-                    if (contains(streamId) && connection.availability() > 0.0 && !receiver.isTerminated()) {
-                        connection
-                            .sendOne(Frame.Cancel.from(streamId))
-                            .doOnError(errorConsumer::accept)
-                            .subscribe();
-                    }
-                    subscribedRequests.cancel();
-                })
-                .doFinally(s -> {
-                    removeReceiver(streamId);
-                    removeSender(streamId);
-                });
+                    .doOnError(t -> sendOneFrame(Frame.Error.from(streamId, t)))
+                    .doOnCancel(() -> {
+                        sendOneFrame(Frame.Cancel.from(streamId));
+                        if (subscribedRequests != null) {
+                            subscribedRequests.cancel();
+                        }
+                    })
+                    .doFinally(s -> {
+                        removeReceiver(streamId);
+                        removeSender(streamId);
+                    });
+            }
         });
     }
 
@@ -363,7 +401,7 @@ public class ClientReactiveSocket implements ReactiveSocket {
             if (type == FrameType.ERROR) {
                 // message for stream that has never existed, we have a problem with
                 // the overall connection and must tear down
-                String errorMessage = getByteBufferAsString(frame.getData());
+                String errorMessage = ByteBufferUtil.toUtf8String(frame.getData());
 
                 throw new IllegalStateException("Client received error for non-existent stream: "
                     + streamId + " Message: " + errorMessage);
@@ -374,16 +412,6 @@ public class ClientReactiveSocket implements ReactiveSocket {
         }
         // receiving a frame after a given stream has been cancelled/completed,
         // so ignore (cancellation is async so there is a race condition)
-    }
-
-    private int nextStreamId() {
-        return streamIdSupplier.nextStreamId();
-    }
-
-    private static String getByteBufferAsString(ByteBuffer bb) {
-        final byte[] bytes = new byte[bb.remaining()];
-        bb.get(bytes);
-        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private synchronized void removeReceiver(int streamId) {

--- a/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
@@ -397,6 +397,11 @@ public class Frame implements Payload {
     public static class Request {
         private Request() {}
 
+        public static Frame from(int streamId, FrameType type, Payload payload, long initialRequestN) {
+            int v = initialRequestN > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) initialRequestN;
+            return from(streamId, type, payload, v);
+        }
+
         public static Frame from(int streamId, FrameType type, Payload payload, int initialRequestN) {
             final ByteBuffer d = payload.getData() != null ? payload.getData() : NULL_BYTEBUFFER;
             final ByteBuffer md = payload.getMetadata() != null ? payload.getMetadata() : NULL_BYTEBUFFER;

--- a/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/Frame.java
@@ -382,6 +382,10 @@ public class Frame implements Payload {
         }
 
         public static Frame from(int streamId, int requestN) {
+            if (requestN < 1) {
+                throw new IllegalStateException("request n must be greater than 0");
+            }
+
             final Frame frame = POOL.acquireFrame(RequestNFrameFlyweight.computeFrameLength());
 
             frame.length = RequestNFrameFlyweight.encode(frame.directBuffer, frame.offset, streamId, requestN);
@@ -403,6 +407,10 @@ public class Frame implements Payload {
         }
 
         public static Frame from(int streamId, FrameType type, Payload payload, int initialRequestN) {
+            if (initialRequestN < 1) {
+                throw new IllegalStateException("initial request n must be greater than 0");
+            }
+
             final ByteBuffer d = payload.getData() != null ? payload.getData() : NULL_BYTEBUFFER;
             final ByteBuffer md = payload.getMetadata() != null ? payload.getMetadata() : NULL_BYTEBUFFER;
 

--- a/reactivesocket-core/src/test/java/io/reactivesocket/FrameTest.java
+++ b/reactivesocket-core/src/test/java/io/reactivesocket/FrameTest.java
@@ -137,7 +137,7 @@ public class FrameTest
         final ByteBuffer requestMetadata = TestUtil.byteBufferFromUtf8String("request metadata");
         final Payload payload = createPayload(requestMetadata, requestData);
 
-        Frame encodedFrame = Frame.Request.from(1, FrameType.FIRE_AND_FORGET, payload, 0);
+        Frame encodedFrame = Frame.Request.from(1, FrameType.FIRE_AND_FORGET, payload, 1);
         TestUtil.copyFrame(reusableMutableDirectBuffer, offset, encodedFrame);
         reusableFrame.wrap(reusableMutableDirectBuffer, offset);
 
@@ -210,7 +210,7 @@ public class FrameTest
         final ByteBuffer requestData = TestUtil.byteBufferFromUtf8String("request data");
         final Payload payload = createPayload(Frame.NULL_BYTEBUFFER, requestData);
 
-        Frame encodedFrame = Frame.Request.from(1, FrameType.FIRE_AND_FORGET, payload, 0);
+        Frame encodedFrame = Frame.Request.from(1, FrameType.FIRE_AND_FORGET, payload, 1);
         TestUtil.copyFrame(reusableMutableDirectBuffer, offset, encodedFrame);
         reusableFrame.wrap(reusableMutableDirectBuffer, offset);
 

--- a/reactivesocket-examples/src/jmh/java/io/reactivesocket/perf/RequestResponsePerf.java
+++ b/reactivesocket-examples/src/jmh/java/io/reactivesocket/perf/RequestResponsePerf.java
@@ -18,20 +18,23 @@ import io.reactivesocket.perf.util.ClientServerHolder;
 import io.reactivesocket.util.PayloadImpl;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 @BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = { "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder" })
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
 @State(Scope.Benchmark)
 public class RequestResponsePerf extends AbstractReactiveSocketPerf {
 

--- a/reactivesocket-examples/src/jmh/java/io/reactivesocket/perf/RequestStreamPerf.java
+++ b/reactivesocket-examples/src/jmh/java/io/reactivesocket/perf/RequestStreamPerf.java
@@ -18,20 +18,23 @@ import io.reactivesocket.perf.util.ClientServerHolder;
 import io.reactivesocket.util.PayloadImpl;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 @BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = { "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder" })
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
 @State(Scope.Benchmark)
 public class RequestStreamPerf extends AbstractReactiveSocketPerf {
 

--- a/reactivesocket-test/src/main/java/io/reactivesocket/test/TestReactiveSocket.java
+++ b/reactivesocket-test/src/main/java/io/reactivesocket/test/TestReactiveSocket.java
@@ -30,7 +30,9 @@ public class TestReactiveSocket extends AbstractReactiveSocket {
 
     @Override
     public Flux<Payload> requestStream(Payload payload) {
-        return requestResponse(payload).repeat(10);
+        return Flux
+            .range(1, 10_000)
+            .flatMap(l -> requestResponse(payload));
     }
 
     @Override

--- a/reactivesocket-transport-netty/src/test/java/io/reactivesocket/transport/netty/TcpClientServerTest.java
+++ b/reactivesocket-transport-netty/src/test/java/io/reactivesocket/transport/netty/TcpClientServerTest.java
@@ -16,7 +16,6 @@
 package io.reactivesocket.transport.netty;
 
 import io.reactivesocket.test.ClientSetupRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,5 +57,10 @@ public class TcpClientServerTest {
     @Test(timeout = 10000)
     public void testRequestStream() {
         setup.testRequestStream();
+    }
+
+    @Test(timeout = 10000)
+    public void testRequestStreamWithRequestN() {
+        setup.testRequestStreamWithRequestN();
     }
 }


### PR DESCRIPTION
Problem
client wasn't sending correct initial request n (#264)

Modification
In LimitableRequestPublisher the added a call to request n after subscription, and in the ClientReactiveSocket moved sending the frames into a doOnRequest() method so that it can get the initial request n. 

Result
client sends initial request n