### PR TITLE
Allow errorConsumer to be set

### DIFF
--- a/reactivesocket-core/src/main/java/io/reactivesocket/ServerReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ServerReactiveSocket.java
@@ -153,9 +153,11 @@ public class ServerReactiveSocket implements ReactiveSocket {
                     Subscriber<Payload> receiver;
                     switch (frame.getType()) {
                         case FIRE_AND_FORGET:
-                            return handleFireAndForget(streamId, fireAndForget(new PayloadImpl(frame)));
+                            return handleFireAndForget(streamId,
+                                fireAndForget(new PayloadImpl(frame)));
                         case REQUEST_RESPONSE:
-                            return handleRequestResponse(streamId, requestResponse(new PayloadImpl(frame)));
+                            return handleRequestResponse(streamId,
+                                requestResponse(new PayloadImpl(frame)));
                         case CANCEL:
                             return handleCancelFrame(streamId);
                         case KEEPALIVE:
@@ -163,7 +165,8 @@ public class ServerReactiveSocket implements ReactiveSocket {
                         case REQUEST_N:
                             return handleRequestN(streamId, frame);
                         case REQUEST_STREAM:
-                            return handleStream(streamId, requestStream(new PayloadImpl(frame)), frame);
+                            return handleStream(streamId, requestStream(new PayloadImpl(frame)),
+                                frame);
                         case REQUEST_CHANNEL:
                             return handleChannel(streamId, frame);
                         case PAYLOAD:
@@ -202,9 +205,11 @@ public class ServerReactiveSocket implements ReactiveSocket {
                             return Mono.empty();
 
                         case SETUP:
-                            return handleError(streamId, new IllegalStateException("Setup frame received post setup."));
+                            return handleError(streamId,
+                                new IllegalStateException("Setup frame received post setup."));
                         default:
-                            return handleError(streamId, new IllegalStateException("ServerReactiveSocket: Unexpected frame type: "
+                            return handleError(streamId, new IllegalStateException(
+                                "ServerReactiveSocket: Unexpected frame type: "
                                     + frame.getType()));
                     }
                 } finally {

--- a/reactivesocket-core/src/main/java/io/reactivesocket/ServerReactiveSocket.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/ServerReactiveSocket.java
@@ -153,11 +153,9 @@ public class ServerReactiveSocket implements ReactiveSocket {
                     Subscriber<Payload> receiver;
                     switch (frame.getType()) {
                         case FIRE_AND_FORGET:
-                            return handleFireAndForget(streamId,
-                                fireAndForget(new PayloadImpl(frame)));
+                            return handleFireAndForget(streamId, fireAndForget(new PayloadImpl(frame)));
                         case REQUEST_RESPONSE:
-                            return handleRequestResponse(streamId,
-                                requestResponse(new PayloadImpl(frame)));
+                            return handleRequestResponse(streamId, requestResponse(new PayloadImpl(frame)));
                         case CANCEL:
                             return handleCancelFrame(streamId);
                         case KEEPALIVE:
@@ -165,8 +163,7 @@ public class ServerReactiveSocket implements ReactiveSocket {
                         case REQUEST_N:
                             return handleRequestN(streamId, frame);
                         case REQUEST_STREAM:
-                            return handleStream(streamId, requestStream(new PayloadImpl(frame)),
-                                frame);
+                            return handleStream(streamId, requestStream(new PayloadImpl(frame)), frame);
                         case REQUEST_CHANNEL:
                             return handleChannel(streamId, frame);
                         case PAYLOAD:
@@ -205,11 +202,9 @@ public class ServerReactiveSocket implements ReactiveSocket {
                             return Mono.empty();
 
                         case SETUP:
-                            return handleError(streamId,
-                                new IllegalStateException("Setup frame received post setup."));
+                            return handleError(streamId, new IllegalStateException("Setup frame received post setup."));
                         default:
-                            return handleError(streamId, new IllegalStateException(
-                                "ServerReactiveSocket: Unexpected frame type: "
+                            return handleError(streamId, new IllegalStateException("ServerReactiveSocket: Unexpected frame type: "
                                     + frame.getType()));
                     }
                 } finally {

--- a/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProvider.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProvider.java
@@ -27,6 +27,7 @@ import io.reactivesocket.lease.DefaultLeaseHonoringSocket;
 import io.reactivesocket.lease.DisableLeaseSocket;
 import io.reactivesocket.lease.LeaseHonoringSocket;
 import io.reactivesocket.util.PayloadImpl;
+import java.util.function.Consumer;
 import reactor.core.publisher.Mono;
 
 import java.util.function.Function;
@@ -93,6 +94,8 @@ public interface SetupProvider {
      * @return A new {@code SetupProvider} instance.
      */
     SetupProvider disableLease(Function<ReactiveSocket, DisableLeaseSocket> socketFactory);
+
+    SetupProvider errorConsumer(Consumer<Throwable> errorConsumer);
 
     /**
      * Creates a new {@code SetupProvider} that uses the passed {@code setupPayload} as the payload for the setup frame.

--- a/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProviderImpl.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/client/SetupProviderImpl.java
@@ -118,6 +118,11 @@ final class SetupProviderImpl implements SetupProvider {
     }
 
     @Override
+    public SetupProvider errorConsumer(Consumer<Throwable> errorConsumer) {
+        return new SetupProviderImpl(setupFrame, leaseDecorator, keepAliveProvider, errorConsumer);
+    }
+
+    @Override
     public SetupProvider setupPayload(Payload setupPayload) {
         Frame newSetup = from(getFlags(setupFrame) & ~ConnectionSetupPayload.HONOR_LEASE,
             keepaliveInterval(setupFrame), maxLifetime(setupFrame),

--- a/reactivesocket-core/src/main/java/io/reactivesocket/server/DefaultReactiveSocketServer.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/server/DefaultReactiveSocketServer.java
@@ -26,15 +26,19 @@ import io.reactivesocket.lease.DefaultLeaseHonoringSocket;
 import io.reactivesocket.lease.LeaseHonoringSocket;
 import io.reactivesocket.transport.TransportServer;
 import io.reactivesocket.transport.TransportServer.StartedServer;
+import java.util.function.Consumer;
 import reactor.core.publisher.Mono;
 
 public final class DefaultReactiveSocketServer
         implements ReactiveSocketServer {
 
     private final TransportServer transportServer;
+    private Consumer<Throwable> errorConsumer;
 
-    public DefaultReactiveSocketServer(TransportServer transportServer) {
+    public DefaultReactiveSocketServer(TransportServer transportServer,
+          Consumer<Throwable> errorConsumer) {
         this.transportServer = transportServer;
+        this.errorConsumer = errorConsumer;
     }
 
     @Override
@@ -72,7 +76,7 @@ public final class DefaultReactiveSocketServer
                                 ServerReactiveSocket receiver = new ServerReactiveSocket(multiplexer.asClientConnection(),
                                     handler,
                                     setup.willClientHonorLease(),
-                                    Throwable::printStackTrace);
+                                    errorConsumer);
                                 receiver.start();
                                 setupFrame.release();
                                 return connection.onClose();

--- a/reactivesocket-core/src/main/java/io/reactivesocket/server/ReactiveSocketServer.java
+++ b/reactivesocket-core/src/main/java/io/reactivesocket/server/ReactiveSocketServer.java
@@ -22,6 +22,7 @@ import io.reactivesocket.exceptions.SetupException;
 import io.reactivesocket.lease.LeaseEnforcingSocket;
 import io.reactivesocket.transport.TransportServer;
 import io.reactivesocket.transport.TransportServer.StartedServer;
+import java.util.function.Consumer;
 
 public interface ReactiveSocketServer {
 
@@ -35,7 +36,12 @@ public interface ReactiveSocketServer {
     StartedServer start(SocketAcceptor acceptor);
 
     static ReactiveSocketServer create(TransportServer transportServer) {
-        return new DefaultReactiveSocketServer(transportServer);
+        return create(transportServer, Throwable::printStackTrace);
+    }
+
+    static ReactiveSocketServer create(TransportServer transportServer,
+        Consumer<Throwable> errorConsumer) {
+        return new DefaultReactiveSocketServer(transportServer, errorConsumer);
     }
 
     /**


### PR DESCRIPTION
This change just make it possible for client and server implementors to provide an alternative errorConsumer